### PR TITLE
Adding mastodon original colors toggle. Partially fixing #90

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 public class GlobalUserPreferences{
+	public static boolean originalColors;
 	public static boolean playGifs;
 	public static boolean useCustomTabs;
 	public static boolean trueBlackTheme;
@@ -15,12 +16,13 @@ public class GlobalUserPreferences{
 	public static boolean disableMarquee;
 	public static ThemePreference theme;
 
-    private static SharedPreferences getPrefs(){
+	private static SharedPreferences getPrefs(){
 		return MastodonApp.context.getSharedPreferences("global", Context.MODE_PRIVATE);
 	}
 
 	public static void load(){
 		SharedPreferences prefs=getPrefs();
+		originalColors=prefs.getBoolean("originalColors", false);
 		playGifs=prefs.getBoolean("playGifs", true);
 		useCustomTabs=prefs.getBoolean("useCustomTabs", true);
 		trueBlackTheme=prefs.getBoolean("trueBlackTheme", false);
@@ -35,6 +37,7 @@ public class GlobalUserPreferences{
 
 	public static void save(){
 		getPrefs().edit()
+				.putBoolean("originalColors", originalColors)
 				.putBoolean("playGifs", playGifs)
 				.putBoolean("useCustomTabs", useCustomTabs)
 				.putBoolean("showReplies", showReplies)
@@ -54,3 +57,4 @@ public class GlobalUserPreferences{
 		DARK
 	}
 }
+

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -99,6 +99,8 @@ public class SettingsFragment extends MastodonToolbarFragment{
 			GlobalUserPreferences.disableMarquee=i.checked;
 			GlobalUserPreferences.save();
 		}));
+		items.add(new SwitchItem(R.string.enable_mastodon_original_colors, R.drawable.bg_button_green, GlobalUserPreferences.originalColors, this::onOriginalColorChanged));
+
 
 		items.add(new HeaderItem(R.string.settings_behavior));
 		items.add(new SwitchItem(R.string.settings_gif, R.drawable.ic_fluent_gif_24_regular, GlobalUserPreferences.playGifs, i->{
@@ -238,6 +240,12 @@ public class SettingsFragment extends MastodonToolbarFragment{
 		if(UiUtils.isDarkTheme()){
 			restartActivityToApplyNewTheme();
 		}
+	}
+
+	private void onOriginalColorChanged(SwitchItem item){
+		GlobalUserPreferences.originalColors=item.checked;
+		GlobalUserPreferences.save();
+		restartActivityToApplyNewTheme();
 	}
 
 	private void restartActivityToApplyNewTheme(){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -662,7 +662,7 @@ public class UiUtils{
 			case LIGHT ->
 					GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Light_Original : R.style.Theme_Mastodon_Light;
 			case DARK ->
-					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark);
+					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack : R.style.Theme_Mastodon_Dark);
 		});
 	}
 	public static boolean isDarkTheme(){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -662,7 +662,7 @@ public class UiUtils{
 			case LIGHT ->
 					GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Light_Original : R.style.Theme_Mastodon_Light;
 			case DARK ->
-					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack : R.style.Theme_Mastodon_Dark);
+					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack : R.style.Theme_Mastodon_Dark);
 		});
 	}
 	public static boolean isDarkTheme(){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -655,14 +655,14 @@ public class UiUtils{
 	}
 
 	public static void setUserPreferredTheme(Context context){
-		boolean isDarkTheme = isDarkTheme();
+//		boolean isDarkTheme = isDarkTheme();
 		context.setTheme(switch(GlobalUserPreferences.theme){
 			case AUTO ->
-					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : (isDarkTheme ? R.style.Theme_Mastodon_Dark_Original : R.style.Theme_Mastodon_AutoLightDark_Original)) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack : R.style.Theme_Mastodon_AutoLightDark);
+					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_AutoLightDark_Original) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack : R.style.Theme_Mastodon_AutoLightDark);
 			case LIGHT ->
 					GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Light_Original : R.style.Theme_Mastodon_Light;
 			case DARK ->
-					GlobalUserPreferences.trueBlackTheme ? (GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_TrueBlack) : (GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Dark_Original : R.style.Theme_Mastodon_Dark);
+					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : R.style.Theme_Mastodon_Dark;
 		});
 	}
 	public static boolean isDarkTheme(){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -655,13 +655,16 @@ public class UiUtils{
 	}
 
 	public static void setUserPreferredTheme(Context context){
+		boolean isDarkTheme = isDarkTheme();
 		context.setTheme(switch(GlobalUserPreferences.theme){
-			case AUTO -> GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack : R.style.Theme_Mastodon_AutoLightDark;
-			case LIGHT -> R.style.Theme_Mastodon_Light;
-			case DARK -> GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack : R.style.Theme_Mastodon_Dark;
+			case AUTO ->
+					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : (isDarkTheme ? R.style.Theme_Mastodon_Dark_Original : R.style.Theme_Mastodon_AutoLightDark_Original)) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack : R.style.Theme_Mastodon_AutoLightDark);
+			case LIGHT ->
+					GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Light_Original : R.style.Theme_Mastodon_Light;
+			case DARK ->
+					GlobalUserPreferences.trueBlackTheme ? (GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_TrueBlack) : (GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Dark_Original : R.style.Theme_Mastodon_Dark);
 		});
 	}
-
 	public static boolean isDarkTheme(){
 		if(GlobalUserPreferences.theme==GlobalUserPreferences.ThemePreference.AUTO)
 			return (MastodonApp.context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)==Configuration.UI_MODE_NIGHT_YES;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -662,7 +662,7 @@ public class UiUtils{
 			case LIGHT ->
 					GlobalUserPreferences.originalColors ? R.style.Theme_Mastodon_Light_Original : R.style.Theme_Mastodon_Light;
 			case DARK ->
-					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : R.style.Theme_Mastodon_Dark;
+					GlobalUserPreferences.originalColors ? (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Original : R.style.Theme_Mastodon_Dark_Original) : (GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark);
 		});
 	}
 	public static boolean isDarkTheme(){

--- a/mastodon/src/main/res/values-night/styles.xml
+++ b/mastodon/src/main/res/values-night/styles.xml
@@ -2,4 +2,7 @@
 <resources>
 	<style name="Theme.Mastodon.AutoLightDark" parent="Theme.Mastodon.Dark"/>
 	<style name="Theme.Mastodon.AutoLightDark.TrueBlack" parent="Theme.Mastodon.Dark.TrueBlack"/>
+
+	<style name="Theme.Mastodon.AutoLightDark.Original" parent="Theme.Mastodon.Dark.Original"/>
+	<style name="Theme.Mastodon.AutoLightDark.TrueBlack.Original" parent="Theme.Mastodon.Dark.TrueBlack.Original"/>
 </resources>

--- a/mastodon/src/main/res/values/colors.xml
+++ b/mastodon/src/main/res/values/colors.xml
@@ -30,6 +30,19 @@
 	<color name="primary_700">#d92aad</color>
 	<color name="primary_800">#ae218a</color>
 	<color name="primary_900">#6d1556</color>
+
+	<color name="original_primary_25">#fafaff</color>
+	<color name="original_primary_50">#f4f3ff</color>
+	<color name="original_primary_100">#ebebff</color>
+	<color name="original_primary_200">#d7d7ff</color>
+	<color name="original_primary_300">#c2c2ff</color>
+	<color name="original_primary_400">#9999ff</color>
+	<color name="original_primary_500">#6364ff</color>
+	<color name="original_primary_600">#562cfc</color>
+	<color name="original_primary_700">#431cbb</color>
+	<color name="original_primary_800">#2f0c7a</color>
+	<color name="original_primary_900">#17063b</color>
+
 	<color name="error_25">#FFFBFA</color>
 	<color name="error_50">#FEF3F2</color>
 	<color name="error_100">#FEE4E2</color>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -427,5 +427,6 @@
 	<string name="your_favorites">Your Favorites</string>
 	<string name="settings_always_reveal_content_warnings">Always reveal content warnings</string>
 	<string name="disable_marquee">Disable scrolling text in title bars</string>
+	<string name="enable_mastodon_original_colors">Enable mastodon original colors</string>
 	<string name="settings_contribute_fork">Contribute to Megalodon</string>
 </resources>

--- a/mastodon/src/main/res/values/styles.xml
+++ b/mastodon/src/main/res/values/styles.xml
@@ -113,6 +113,31 @@
 	<style name="Theme.Mastodon.AutoLightDark" parent="Theme.Mastodon.Light"/>
 	<style name="Theme.Mastodon.AutoLightDark.TrueBlack" parent="Theme.Mastodon.Light"/>
 
+	<style name="Theme.Mastodon.Dark.Original" parent="Theme.Mastodon.Dark">
+		<item name="android:colorAccent">@color/original_primary_400</item>
+		<item name="colorPollMostVoted">@color/original_primary_700</item>
+		<item name="colorAccentLight">@color/original_primary_600</item>
+		<item name="colorAccentLightest">@color/original_primary_800</item>
+	</style>
+
+	<style name="Theme.Mastodon.Dark.TrueBlack.Original" parent="Theme.Mastodon.Dark.TrueBlack">
+		<item name="android:colorAccent">@color/original_primary_400</item>
+		<item name="colorPollMostVoted">@color/original_primary_700</item>
+		<item name="colorAccentLight">@color/original_primary_600</item>
+		<item name="colorAccentLightest">@color/original_primary_800</item>
+	</style>
+
+	<style name="Theme.Mastodon.Light.Original" parent="Theme.Mastodon.Light">
+		<item name="android:colorAccent">@color/original_primary_400</item>
+		<item name="colorPollMostVoted">@color/original_primary_700</item>
+		<item name="colorAccentLight">@color/original_primary_600</item>
+		<item name="colorAccentLightest">@color/original_primary_800</item>
+	</style>
+
+	<style name="Theme.Mastodon.AutoLightDark.Original" parent="Theme.Mastodon.Light.Original"/>
+	<style name="Theme.Mastodon.AutoLightDark.TrueBlack.Original" parent="Theme.Mastodon.Dark.TrueBlack.Original"/>
+
+
 	<style name="Theme.Mastodon.Toolbar" parent="android:ThemeOverlay.Material.ActionBar">
 		<item name="android:colorPrimary">@color/gray_50</item>
 		<item name="android:textColorPrimary">@color/gray_800</item>

--- a/mastodon/src/main/res/values/styles.xml
+++ b/mastodon/src/main/res/values/styles.xml
@@ -135,7 +135,7 @@
 	</style>
 
 	<style name="Theme.Mastodon.AutoLightDark.Original" parent="Theme.Mastodon.Light.Original"/>
-	<style name="Theme.Mastodon.AutoLightDark.TrueBlack.Original" parent="Theme.Mastodon.Dark.TrueBlack.Original"/>
+	<style name="Theme.Mastodon.AutoLightDark.TrueBlack.Original" parent="Theme.Mastodon.Light.Original"/>
 
 
 	<style name="Theme.Mastodon.Toolbar" parent="android:ThemeOverlay.Material.ActionBar">


### PR DESCRIPTION
This commit is adding the mastodon original color toggle. Partially addressing #90. The implementation is quite clean, and i feel confident i can add more color options in the future. For now though, the pinkish and purplish colors are the only options.