### PR TITLE
feat(theme): add Nord theme

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -93,7 +93,8 @@ public class GlobalUserPreferences{
 		BROWN,
 		RED,
 		ORANGE,
-		YELLOW
+		YELLOW,
+		NORD
 	}
 
 	public enum ThemePreference{

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -255,6 +255,7 @@ public class SettingsFragment extends MastodonToolbarFragment{
 		else if (id == R.id.brown_color) pref = ColorPreference.BROWN;
 		else if (id == R.id.red_color) pref = ColorPreference.RED;
 		else if (id == R.id.yellow_color) pref = ColorPreference.YELLOW;
+		else if (id == R.id.nord_color) pref = ColorPreference.NORD;
 
 		if (pref == null) return false;
 
@@ -717,6 +718,7 @@ public class SettingsFragment extends MastodonToolbarFragment{
 				case BROWN -> R.string.sk_color_theme_brown;
 				case RED -> R.string.sk_color_theme_red;
 				case YELLOW -> R.string.sk_color_theme_yellow;
+				case NORD -> R.string.sk_color_theme_nord;
 				default -> throw new IllegalStateException("Unexpected value: "+GlobalUserPreferences.color);
 			});
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -738,6 +738,16 @@ public class UiUtils{
 							GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack_Material3 : R.style.Theme_Mastodon_Dark_Material3;
 				});
 				break;
+			case NORD:
+				context.setTheme(switch(GlobalUserPreferences.theme){
+					case AUTO ->
+							GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_AutoLightDark_TrueBlack_Nord : R.style.Theme_Mastodon_AutoLightDark_Nord;
+					case LIGHT ->
+							R.style.Theme_Mastodon_Light_Nord;
+					case DARK ->
+							GlobalUserPreferences.trueBlackTheme ? R.style.Theme_Mastodon_Dark_TrueBlack_Nord : R.style.Theme_Mastodon_Dark_Nord;
+				});
+				break;
 		}
 
 	}

--- a/mastodon/src/main/res/menu/color_picker.xml
+++ b/mastodon/src/main/res/menu/color_picker.xml
@@ -8,4 +8,5 @@
     <item android:id="@+id/brown_color" android:title="@string/sk_color_theme_brown"/>
     <item android:id="@+id/red_color" android:title="@string/sk_color_theme_red"/>
     <item android:id="@+id/yellow_color" android:title="@string/sk_color_theme_yellow"/>
+    <item android:id="@+id/nord_color" android:title="@string/sk_color_theme_nord"/>
 </menu>

--- a/mastodon/src/main/res/values/colors.xml
+++ b/mastodon/src/main/res/values/colors.xml
@@ -270,4 +270,21 @@
 	<color name="m3_sys_dark_on_surface_variant">#CAC4D0</color>
 	<color name="m3_sys_dark_outline">#938F99</color>
 
+	<!-- nord theme -->
+	<color name="nord_0">#2E3440</color>
+	<color name="nord_1">#3B4252</color>
+	<color name="nord_2">#434C5E</color>
+	<color name="nord_3">#4C566A</color>
+	<color name="nord_4">#D8DEE9</color>
+	<color name="nord_5">#E5E9F0</color>
+	<color name="nord_6">#ECEFF4</color>
+	<color name="nord_7">#8FBCBB</color>
+	<color name="nord_8">#88C0D0</color>
+	<color name="nord_9">#81A1C1</color>
+	<color name="nord_10">#5E81AC</color>
+	<color name="nord_11">#BF616A</color>
+	<color name="nord_12">#D08770</color>
+	<color name="nord_13">#EBCB8B</color>
+	<color name="nord_14">#A3BE8C</color>
+	<color name="nord_15">#B48EAD</color>
 </resources>

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -422,4 +422,5 @@
 	<string name="not_accepting_new_members">Not accepting new members</string>
 	<string name="category_special_interests">Special Interests</string>
 	<string name="signup_passwords_dont_match">Passwords don\'t match</string>
+    <string name="sk_color_theme_nord">Nord</string>
 </resources>

--- a/mastodon/src/main/res/values/styles.xml
+++ b/mastodon/src/main/res/values/styles.xml
@@ -549,6 +549,159 @@
 	</style>
 
 
+	<style name="Theme.Mastodon.Light.Nord" parent="Theme.Mastodon.Light.CustomBase">
+		<item name="android:colorAccent">@color/nord_8</item>
+		<item name="android:colorBackground">@color/nord_6</item>
+		<item name="colorSecondary">@color/nord_7</item>
+		<item name="colorButtonText">@color/nord_4</item>
+		<item name="colorBackgroundLight">@color/nord_4</item>
+		<item name="colorBackgroundLightest">@color/green_gray_25</item>
+		<item name="android:statusBarColor">@color/nord_4</item>
+		<item name="android:navigationBarColor">@color/green_navigation_bar_bg</item>
+		<item name="android:actionBarTheme">@style/Theme.Mastodon.Toolbar.Nord</item>
+		<item name="android:alertDialogTheme">@style/Theme.Mastodon.Dialog.Alert.Nord</item>
+		<item name="colorPollMostVoted">@color/nord_8</item>
+		<item name="colorPollVoted">@color/nord_9</item>
+		<item name="colorAccentLight">@color/green_primary_600</item>
+		<item name="colorSearchField">@color/nord_5</item>
+		<item name="colorTabInactive">@color/nord_3</item>
+		<item name="colorAccentLightest">@color/nord_9</item>
+
+
+		<!-- colors for button_bg|text_primary|secondary_dark|light_on_light|dark.xml -->
+		<item name="colorButtonBackgroundPrimaryDarkOnLight">@color/nord_0</item>
+		<item name="colorButtonBackgroundPrimaryDarkOnLightDisabled">@color/nord_1</item>
+		<item name="colorButtonTextPrimaryDarkOnLight">@color/nord_4</item>
+		<item name="colorButtonTextPrimaryDarkOnLightDisabled">@color/gray_400</item>
+
+		<item name="colorButtonBackgroundPrimaryLightOnDark">@color/nord_2</item>
+		<item name="colorButtonBackgroundPrimaryLightOnDarkDisabled">@color/nord_3</item>
+		<item name="colorButtonTextPrimaryLightOnDark">@color/nord_6</item>
+		<item name="colorButtonTextPrimaryLightOnDarkDisabled">@color/gray_50</item>
+
+		<item name="colorButtonBackgroundSecondaryDarkOnLight">@color/nord_8</item>
+		<item name="colorButtonBackgroundSecondaryDarkOnLightDisabled">@color/nord_7</item>
+		<item name="colorButtonTextSecondaryDarkOnLight">@color/nord_6</item>
+		<item name="colorButtonTextSecondaryDarkOnLightDisabled">@color/gray_50</item>
+
+		<item name="colorButtonBackgroundSecondaryLightOnDark">@color/nord_2</item>
+		<item name="colorButtonBackgroundSecondaryLightOnDarkDisabled">@color/nord_1</item>
+		<item name="colorButtonTextSecondaryLightOnDark">@color/nord_6</item>
+		<item name="colorButtonTextSecondaryLightOnDarkDisabled">@color/gray_50</item>
+	</style>
+
+	<style name="Theme.Mastodon.Dark.Nord" parent="Theme.Mastodon.Dark.CustomBase">
+		<item name="android:colorAccent">@color/nord_8</item>
+		<item name="android:colorBackground">@color/nord_0</item>
+		<item name="android:colorPrimary">@color/nord_8</item>
+		<item name="android:textColorPrimary">@color/nord_6</item>
+		<item name="android:textColorSecondary">@color/nord_5</item>
+		<item name="android:alertDialogTheme">@style/Theme.Mastodon.Dialog.Alert.Dark.Nord</item>
+		<item name="colorPollMostVoted">@color/nord_8</item>
+		<item name="colorPollVoted">@color/nord_10</item>
+		<item name="colorAccentLight">@color/nord_9</item>
+		<item name="colorAccentLightest">@color/nord_8</item>
+		<item name="colorTabInactive">@color/nord_3</item>
+		<item name="colorSearchHint">@color/nord_4</item>
+		<item name="colorSecondary">@color/nord_7</item>
+		<item name="colorWindowBackground">@color/nord_0</item>
+		<item name="android:statusBarColor">@color/nord_0</item>
+		<item name="android:navigationBarColor">@color/nord_0</item>
+		<item name="colorBackgroundLightest">@color/nord_3</item>
+		<item name="colorSearchField">@color/nord_2</item>
+		<item name="colorBackgroundPopup">@color/nord_2</item>
+		<item name="colorButtonText">@color/nord_3</item>
+		<item name="colorBackgroundLight">@color/nord_2</item>
+		<item name="android:actionBarTheme">@style/Theme.Mastodon.Toolbar.Dark.Nord</item>
+
+
+
+		<!-- colors for button_bg|text_primary|secondary_dark|light_on_light|dark.xml -->
+		<item name="colorButtonBackgroundPrimaryDarkOnLight">@color/nord_7</item>
+		<item name="colorButtonBackgroundPrimaryDarkOnLightDisabled">@color/nord_3</item>
+		<item name="colorButtonTextPrimaryDarkOnLight">@color/nord_6</item>
+		<item name="colorButtonTextPrimaryDarkOnLightDisabled">@color/nord_2</item>
+
+		<item name="colorButtonBackgroundPrimaryLightOnDark">@color/nord_8</item>
+		<item name="colorButtonBackgroundPrimaryLightOnDarkDisabled">@color/nord_7</item>
+		<item name="colorButtonTextPrimaryLightOnDark">@color/nord_6</item>
+		<item name="colorButtonTextPrimaryLightOnDarkDisabled">@color/gray_50</item>
+
+		<item name="colorButtonBackgroundSecondaryDarkOnLight">@color/green_gray_25</item>
+		<item name="colorButtonBackgroundSecondaryDarkOnLightDisabled">@color/nord_0</item>
+		<item name="colorButtonTextSecondaryDarkOnLight">@color/nord_6</item>
+		<item name="colorButtonTextSecondaryDarkOnLightDisabled">@color/gray_50</item>
+
+		<item name="colorButtonBackgroundSecondaryLightOnDark">@color/nord_7</item>
+		<item name="colorButtonBackgroundSecondaryLightOnDarkDisabled">@color/nord_8</item>
+		<item name="colorButtonTextSecondaryLightOnDark">@color/nord_6</item>
+		<item name="colorButtonTextSecondaryLightOnDarkDisabled">@color/gray_50</item>
+	</style>
+
+	<style name="Theme.Mastodon.Dark.TrueBlack.Nord" parent="Theme.Mastodon.Dark.Nord">
+		<item name="android:colorAccent">@color/nord_8</item>
+		<item name="colorPollMostVoted">@color/nord_8</item>
+		<item name="colorAccentLight">@color/nord_10</item>
+		<item name="colorAccentLightest">@color/nord_8</item>
+		<item name="colorSecondary">@color/nord_7</item>
+
+		<item name="colorPollVoted">@color/nord_10</item>
+		<item name="colorSearchField">@color/nord_2</item>
+		<item name="colorBackgroundPopup">@color/nord_2</item>
+		<item name="android:navigationBarColor">@color/black</item>
+		<item name="android:colorBackground">@color/black</item>
+		<item name="android:statusBarColor">@color/black</item>
+		<item name="android:actionBarTheme">@style/Theme.Mastodon.Toolbar.Dark.TrueBlack</item>
+		<item name="colorBackgroundLight">@color/black</item>
+		<item name="colorWindowBackground">@color/black</item>
+		<item name="colorButtonText">@color/black</item>
+		<item name="colorBackgroundLightest">@color/black</item>
+	</style>
+
+	<style name="Theme.Mastodon.AutoLightDark.Nord" parent="Theme.Mastodon.Light.Nord"/>
+	<style name="Theme.Mastodon.AutoLightDark.TrueBlack.Nord" parent="Theme.Mastodon.Light.Nord"/>
+
+	<style name="Theme.Mastodon.Dialog.Alert.Dark.Nord" parent="android:Theme.Material.Dialog.Alert">
+		<item name="android:windowTitleStyle">@style/alert_title</item>
+		<item name="android:dialogPreferredPadding">24dp</item>
+		<item name="android:windowBackground">@drawable/bg_alert</item>
+		<item name="android:buttonBarButtonStyle">@style/Widget.Mastodon.ButtonBarButton</item>
+
+		<!-- colors -->
+		<item name="android:colorAccent">@color/nord_8</item>
+		<item name="android:colorPrimary">@color/nord_10</item>
+		<item name="android:colorBackground">@color/nord_0</item>
+		<item name="android:textColorPrimary">@color/nord_5</item>
+		<item name="android:textColorSecondary">@color/nord_6</item>
+	</style>
+
+	<style name="Theme.Mastodon.Dialog.Alert.Nord" parent="android:Theme.Material.Light.Dialog.Alert">
+		<item name="android:windowTitleStyle">@style/alert_title</item>
+		<item name="android:dialogPreferredPadding">24dp</item>
+		<item name="android:windowBackground">@drawable/bg_alert</item>
+		<item name="android:buttonBarButtonStyle">@style/Widget.Mastodon.ButtonBarButton</item>
+
+		<!-- colors -->
+		<item name="android:colorAccent">@color/nord_8</item>
+		<item name="android:colorPrimary">@color/nord_7</item>
+		<item name="android:colorBackground">@color/nord_4</item>
+		<item name="android:textColorPrimary">@color/nord_0</item>
+		<item name="android:textColorSecondary">@color/nord_2</item>
+	</style>
+
+	<style name="Theme.Mastodon.Toolbar.Nord" parent="android:ThemeOverlay.Material.ActionBar">
+		<item name="android:colorPrimary">@color/nord_4</item>
+		<item name="android:textColorPrimary">@color/nord_0</item>
+		<item name="android:textColorSecondary">@color/nord_0</item>
+	</style>
+
+	<style name="Theme.Mastodon.Toolbar.Dark.Nord" parent="android:ThemeOverlay.Material.ActionBar">
+		<item name="android:colorPrimary">@color/nord_0</item>
+		<item name="android:textColorPrimary">@color/nord_4</item>
+		<item name="android:textColorSecondary">@color/nord_5</item>
+	</style>
+
+
 	<style name="Theme.Mastodon.Light.Blue" parent="Theme.Mastodon.Light.CustomBase">
 		<item name="android:colorAccent">@color/blue_primary_700</item>
 		<item name="android:colorBackground">@color/blue_gray_100</item>


### PR DESCRIPTION
This pr adds a [Nord theme option](https://nordtheme.com). 


<details>
<summary>Light</summary>

![Post](https://user-images.githubusercontent.com/63370021/208306725-57fd4afa-14cc-47c6-9e80-ab53a180a48d.png)
![Poll](https://user-images.githubusercontent.com/63370021/208306740-bd6c7902-e865-4309-8759-3e630e185f4e.png)
![Profile](https://user-images.githubusercontent.com/63370021/208306728-360e0680-8f11-4b55-abfe-9ba06ea9a2b8.png)
![Profile About](https://user-images.githubusercontent.com/63370021/208306731-318d25f8-9ea1-42e1-b093-6e972f5e1124.png)
![Settings](https://user-images.githubusercontent.com/63370021/208306736-116d3b52-a4a9-4990-a73e-b49cdfaa2e08.png)

</details>

<details>
<summary>Dark</summary>

![Post](https://user-images.githubusercontent.com/63370021/208306496-25410a95-4025-4f62-9183-e8b25a7aacdf.png)
![Poll](https://user-images.githubusercontent.com/63370021/208306498-353fe7f3-b01d-4cd9-a25b-20faa607fb87.png)
![Profile](https://user-images.githubusercontent.com/63370021/208306509-d7ed47f3-4a1a-4990-a2fc-bbb5b736ecfb.png)
![Profile About](https://user-images.githubusercontent.com/63370021/208306501-6a723b06-4b51-41cd-bea2-f9c7c74bf01f.png)
![Settings](https://user-images.githubusercontent.com/63370021/208306494-28d3795d-a332-4b11-9535-3d48a6edef23.png)

</details>