### PR TITLE
Feat/4.0 filters with hide action

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/model/Filter.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Filter.java
@@ -6,12 +6,14 @@ import com.google.gson.annotations.SerializedName;
 
 import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
+import org.parceler.Parcel;
 
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.regex.Pattern;
 
+@Parcel
 public class Filter extends BaseModel{
 	@RequiredField
 	public String id;
@@ -21,6 +23,7 @@ public class Filter extends BaseModel{
 	public Instant expiresAt;
 	public boolean irreversible;
 	public boolean wholeWord;
+	public String filterAction;
 
 	@SerializedName("context")
 	private List<FilterContext> _context;

--- a/mastodon/src/main/java/org/joinmastodon/android/model/FilterResult.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/FilterResult.java
@@ -1,0 +1,8 @@
+package org.joinmastodon.android.model;
+
+import org.parceler.Parcel;
+
+@Parcel
+public class FilterResult extends BaseModel {
+    public Filter filter;
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
@@ -40,6 +40,7 @@ public class Status extends BaseModel implements DisplayItemsParent{
 	public long favouritesCount;
 	public long repliesCount;
 	public Instant editedAt;
+	public List<FilterResult> filtered;
 
 	public String url;
 	public String inReplyToId;

--- a/mastodon/src/main/java/org/joinmastodon/android/utils/StatusFilterPredicate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/StatusFilterPredicate.java
@@ -5,6 +5,7 @@ import org.joinmastodon.android.model.Filter;
 import org.joinmastodon.android.model.FilterResult;
 import org.joinmastodon.android.model.Status;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -23,6 +24,8 @@ public class StatusFilterPredicate implements Predicate<Status>{
 	@Override
 	public boolean test(Status status){
 		for(FilterResult filterResult:status.filtered){
+			if (filterResult.filter.expiresAt.isAfter(Instant.now()))
+				continue;
 			if (filterResult.filter.filterAction.equals("hide"))
 				return false;
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/utils/StatusFilterPredicate.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/StatusFilterPredicate.java
@@ -2,6 +2,7 @@ package org.joinmastodon.android.utils;
 
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Filter;
+import org.joinmastodon.android.model.FilterResult;
 import org.joinmastodon.android.model.Status;
 
 import java.util.List;
@@ -21,6 +22,10 @@ public class StatusFilterPredicate implements Predicate<Status>{
 
 	@Override
 	public boolean test(Status status){
+		for(FilterResult filterResult:status.filtered){
+			if (filterResult.filter.filterAction.equals("hide"))
+				return false;
+		}
 		for(Filter filter:filters){
 			if(filter.matches(status))
 				return false;


### PR DESCRIPTION
Partially fixes #161

Mastodon 4.0 adds a new filter mechanism (stated by https://github.com/mastodon/mastodon-android/issues/94#issuecomment-1321799377 ). This changing should make the "hide" action to work properly with this new field. 

Should help with the "warn" action, but it involves UI changes that I'm not (yet) sure I know how to do.
