### PR TITLE
Fix filtered posts showing during "auto refresh"

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
@@ -188,10 +188,8 @@ public class HomeTimelineFragment extends StatusListFragment{
 							result.get(result.size()-1).hasGapAfter=true;
 							toAdd=result;
 						}
-						List<Filter> filters=AccountSessionManager.getInstance().getAccount(accountID).wordFilters.stream().filter(f->f.context.contains(Filter.FilterContext.HOME)).collect(Collectors.toList());
-						if(!filters.isEmpty()){
-							toAdd=toAdd.stream().filter(new StatusFilterPredicate(filters)).collect(Collectors.toList());
-						}
+						StatusFilterPredicate filterPredicate=new StatusFilterPredicate(accountID, Filter.FilterContext.HOME);
+						toAdd=toAdd.stream().filter(filterPredicate).collect(Collectors.toList());
 						if(!toAdd.isEmpty()){
 							prependItems(toAdd, true);
 							showNewPostsButton();


### PR DESCRIPTION
I've been experiencing a bug where, after the app is idle for a while, filtered ("hide") posts are appearing in the home timeline. I could not reproduce in debug mode, but it is happening somewhat consistently in the Play Store apk for me.

I guess it is related to empty `wordFilters` list as it's the only difference between manual refresh and auto refresh. Is it possible that we're not calling `maybeUpdateLocalInfo()`?

Anyway, I removed the `filters.isEmpty()` validation so status with `filtered` can still be checked. The semantics is the same as the constructor `StatusFilterPredicate(String accountID, Filter.FilterContext context)` still checks for `wordFilters`.