### PR TITLE
feat(settings): add about instance link

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -243,6 +243,7 @@ public class SettingsFragment extends MastodonToolbarFragment{
 			args.putParcelable("instance", Parcels.wrap(instance));
 			Nav.go(getActivity(), InstanceRulesFragment.class, args);
 		}, R.drawable.ic_fluent_task_list_ltr_24_regular));
+		items.add(new TextItem(R.string.sk_settings_about_instance	, ()->UiUtils.launchWebBrowser(getActivity(), "https://"+session.domain+"/about"), R.drawable.ic_fluent_open_24_regular));
 		items.add(new TextItem(R.string.settings_tos, ()->UiUtils.launchWebBrowser(getActivity(), "https://"+session.domain+"/terms"), R.drawable.ic_fluent_open_24_regular));
 		items.add(new TextItem(R.string.settings_privacy_policy, ()->UiUtils.launchWebBrowser(getActivity(), "https://"+session.domain+"/terms"), R.drawable.ic_fluent_open_24_regular));
 		items.add(new TextItem(R.string.log_out, this::confirmLogOut, R.drawable.ic_fluent_sign_out_24_regular));

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -127,4 +127,5 @@
     <string name="sk_settings_reduce_motion">Reduce motion in animations</string>
     <string name="sk_announcements">Announcements</string>
     <string name="sk_mark_as_read">Mark as read</string>
+    <string name="sk_settings_about_instance">About</string>
 </resources>


### PR DESCRIPTION
Adds a link to the about page of the home instance. Closes #261.

![Example with about link](https://user-images.githubusercontent.com/63370021/211407290-7dc7a40f-5b92-480d-87f5-2a0d92e38da1.png)