### PR TITLE
Fix EditTimelines popup not responding until second click

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -270,8 +270,16 @@ public class EditTimelinesFragment extends BaseRecyclerFragment<TimelineDefiniti
             TimelineDefinition.Icon currentIcon = item.getIcon();
             btn.setImageResource(currentIcon.iconRes);
             btn.setContentDescription(ctx.getString(currentIcon.nameRes));
-            btn.setOnTouchListener(popup.getDragToOpenListener());
-            btn.setOnClickListener(l -> popup.show());
+            View.OnTouchListener touchListener = (v, event) -> {
+                if(event.getAction() == MotionEvent.ACTION_UP){
+                    popup.show();
+                    return true;
+                } else {
+                    popup.getDragToOpenListener();
+                }
+                return false;
+            };
+            btn.setOnTouchListener(touchListener);
 
             Menu menu = popup.getMenu();
             TimelineDefinition.Icon defaultIcon = item.getDefaultIcon();


### PR DESCRIPTION
## Overview
Fix for the `IconButton` not responding to `onClick` until a subsequent click by using `OnTouchListener` to consume the `ACTION_UP` event.

Solution Credit: https://stackoverflow.com/a/51350749/3645949

## Video
https://user-images.githubusercontent.com/45771676/213948823-d43acb80-77c4-48f2-86f7-0d71da54099b.mp4

