### PR TITLE
Prefix replies with "re:"

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -39,6 +39,7 @@ public class GlobalUserPreferences{
 	public static boolean showAltIndicator;
 	public static boolean showNoAltIndicator;
 	public static boolean enablePreReleases;
+	public static boolean prefixRepliesWithRe;
 	public static String publishButtonText;
 	public static ThemePreference theme;
 	public static ColorPreference color;
@@ -83,6 +84,7 @@ public class GlobalUserPreferences{
 		showAltIndicator=prefs.getBoolean("showAltIndicator", true);
 		showNoAltIndicator=prefs.getBoolean("showNoAltIndicator", true);
 		enablePreReleases=prefs.getBoolean("enablePreReleases", false);
+		prefixRepliesWithRe=prefs.getBoolean("prefixRepliesWithRe", false);
 		publishButtonText=prefs.getString("publishButtonText", "");
 		theme=ThemePreference.values()[prefs.getInt("theme", 0)];
 		recentLanguages=fromJson(prefs.getString("recentLanguages", null), recentLanguagesType, new HashMap<>());
@@ -120,6 +122,7 @@ public class GlobalUserPreferences{
 				.putBoolean("showAltIndicator", showAltIndicator)
 				.putBoolean("showNoAltIndicator", showNoAltIndicator)
 				.putBoolean("enablePreReleases", enablePreReleases)
+				.putBoolean("prefixRepliesWithRe", prefixRepliesWithRe)
 				.putString("publishButtonText", publishButtonText)
 				.putInt("theme", theme.ordinal())
 				.putString("color", color.name())

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -710,7 +710,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 				if(!TextUtils.isEmpty(replyTo.spoilerText)){
 					hasSpoiler=true;
 					spoilerEdit.setVisibility(View.VISIBLE);
-					if(GlobalUserPreferences.prefixRepliesWithRe){
+					if(GlobalUserPreferences.prefixRepliesWithRe && !replyTo.spoilerText.startsWith("re: ")){
 						spoilerEdit.setText("re: " + replyTo.spoilerText);
 					}else{
 						spoilerEdit.setText(replyTo.spoilerText);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -710,7 +710,11 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 				if(!TextUtils.isEmpty(replyTo.spoilerText)){
 					hasSpoiler=true;
 					spoilerEdit.setVisibility(View.VISIBLE);
-					spoilerEdit.setText(replyTo.spoilerText);
+					if(GlobalUserPreferences.prefixRepliesWithRe){
+						spoilerEdit.setText("re: " + replyTo.spoilerText);
+					}else{
+						spoilerEdit.setText(replyTo.spoilerText);
+					}
 					spoilerBtn.setSelected(true);
 				}
 				if (replyTo.language != null && !replyTo.language.isEmpty()) updateLanguage(replyTo.language);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -202,6 +202,10 @@ public class SettingsFragment extends MastodonToolbarFragment{
 			GlobalUserPreferences.keepOnlyLatestNotification=i.checked;
 			GlobalUserPreferences.save();
 		}));
+		items.add(new SwitchItem(R.string.sk_settings_prefix_replies_with_re, R.drawable.ic_fluent_arrow_reply_24_regular, GlobalUserPreferences.prefixRepliesWithRe, i->{
+			GlobalUserPreferences.prefixRepliesWithRe=i.checked;
+			GlobalUserPreferences.save();
+		}));
 
 		items.add(new HeaderItem(R.string.sk_timelines));
 		items.add(new SwitchItem(R.string.sk_settings_show_replies, R.drawable.ic_fluent_chat_multiple_24_regular, GlobalUserPreferences.showReplies, i->{

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -251,5 +251,5 @@
     <string name="sk_new_reports">New reports</string>
     <string name="sk_settings_server_version">Server version: %s</string>
     <string name="sk_notify_poll_results">Poll results</string>
-    <string name="sk_settings_prefix_replies_with_re">Prefix replies with "re:"</string>
+    <string name="sk_settings_prefix_replies_with_re">Prefix replies with “re:”</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -251,4 +251,5 @@
     <string name="sk_new_reports">New reports</string>
     <string name="sk_settings_server_version">Server version: %s</string>
     <string name="sk_notify_poll_results">Poll results</string>
+    <string name="sk_settings_prefix_replies_with_re">Prefix replies with "re:"</string>
 </resources>


### PR DESCRIPTION
#317. Adds "re:" when replying to a CW'd post

<img src="https://user-images.githubusercontent.com/26420060/215193008-46c4783a-1b52-4ac7-ad19-d6523931f53f.png" alt="Compose screen" width=300/>

<img src="https://user-images.githubusercontent.com/26420060/215192216-f99f5548-74ba-4110-bc87-cbb0c33af52d.png" width=200 alt="Settings screen, highlighting the 'Prefix replies with re:' option"/>

