### PR TITLE
feat(post): truncate long posts

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ScheduledStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ScheduledStatusListFragment.java
@@ -69,7 +69,7 @@ public class ScheduledStatusListFragment extends BaseStatusListFragment<Schedule
 
 	@Override
 	protected List<StatusDisplayItem> buildDisplayItems(ScheduledStatus s) {
-		return StatusDisplayItem.buildItems(this, s.toStatus(), accountID, s, knownAccounts, false, false, null, true);
+		return StatusDisplayItem.buildItems(this, s.toStatus(), accountID, s, knownAccounts, false, false, null, true, true);
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusEditHistoryFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusEditHistoryFragment.java
@@ -55,7 +55,7 @@ public class StatusEditHistoryFragment extends StatusListFragment{
 
 	@Override
 	protected List<StatusDisplayItem> buildDisplayItems(Status s){
-		List<StatusDisplayItem> items=StatusDisplayItem.buildItems(this, s, accountID, s, knownAccounts, true, false, null);
+		List<StatusDisplayItem> items=StatusDisplayItem.buildItems(this, s, accountID, s, knownAccounts, true, false, null, false, false);
 		int idx=data.indexOf(s);
 		if(idx>=0){
 			String date=UiUtils.DATE_TIME_FORMATTER.format(s.createdAt.atZone(ZoneId.systemDefault()));

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
@@ -45,9 +45,10 @@ public class ThreadFragment extends StatusListFragment{
 		List<StatusDisplayItem> items=super.buildDisplayItems(s);
 		if(s.id.equals(mainStatus.id)){
 			for(StatusDisplayItem item:items){
-				if(item instanceof TextStatusDisplayItem text)
+				if(item instanceof TextStatusDisplayItem text) {
 					text.textSelectable=true;
-				else if(item instanceof FooterStatusDisplayItem footer)
+					text.shouldTruncate = false;
+				} else if(item instanceof FooterStatusDisplayItem footer)
 					footer.hideCounts=true;
 			}
 			items.add(new ExtendedFooterStatusDisplayItem(s.id, this, s.getContentStatus()));

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -83,10 +83,10 @@ public abstract class StatusDisplayItem{
 	}
 
 	public static ArrayList<StatusDisplayItem> buildItems(BaseStatusListFragment fragment, Status status, String accountID, DisplayItemsParent parentObject, Map<String, Account> knownAccounts, boolean inset, boolean addFooter, Notification notification){
-		return buildItems(fragment, status, accountID, parentObject, knownAccounts, inset, addFooter, notification, false);
+		return buildItems(fragment, status, accountID, parentObject, knownAccounts, inset, addFooter, notification, false, true);
 	}
 
-	public static ArrayList<StatusDisplayItem> buildItems(BaseStatusListFragment fragment, Status status, String accountID, DisplayItemsParent parentObject, Map<String, Account> knownAccounts, boolean inset, boolean addFooter, Notification notification, boolean disableTranslate){
+	public static ArrayList<StatusDisplayItem> buildItems(BaseStatusListFragment fragment, Status status, String accountID, DisplayItemsParent parentObject, Map<String, Account> knownAccounts, boolean inset, boolean addFooter, Notification notification, boolean disableTranslate, boolean shouldTruncate){
 		String parentID=parentObject.getID();
 		ArrayList<StatusDisplayItem> items=new ArrayList<>();
 		Status statusForContent=status.getContentStatus();
@@ -128,9 +128,11 @@ public abstract class StatusDisplayItem{
 		}
 		HeaderStatusDisplayItem header;
 		items.add(header=new HeaderStatusDisplayItem(parentID, statusForContent.account, statusForContent.createdAt, fragment, accountID, statusForContent, null, notification, scheduledStatus));
-		if(!TextUtils.isEmpty(statusForContent.content))
-			items.add(new TextStatusDisplayItem(parentID, HtmlParser.parse(statusForContent.content, statusForContent.emojis, statusForContent.mentions, statusForContent.tags, accountID), fragment, statusForContent, disableTranslate));
-		else
+		if(!TextUtils.isEmpty(statusForContent.content)) {
+			TextStatusDisplayItem textStatusDisplayItem = new TextStatusDisplayItem(parentID, HtmlParser.parse(statusForContent.content, statusForContent.emojis, statusForContent.mentions, statusForContent.tags, accountID), fragment, statusForContent, disableTranslate);
+			textStatusDisplayItem.shouldTruncate = shouldTruncate;
+			items.add(textStatusDisplayItem);
+		} else
 			header.needBottomPadding=true;
 		List<Attachment> imageAttachments=statusForContent.mediaAttachments.stream().filter(att->att.type.isImage()).collect(Collectors.toList());
 		if(!imageAttachments.isEmpty()){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
@@ -1,11 +1,17 @@
 package org.joinmastodon.android.ui.displayitems;
 
 import android.app.Activity;
+import android.graphics.Color;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.LayerDrawable;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextPaint;
 import android.text.TextUtils;
-import android.util.TypedValue;
+import android.text.style.ClickableSpan;
+import android.text.style.ForegroundColorSpan;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -20,7 +26,6 @@ import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.Status;
-import org.joinmastodon.android.ui.drawables.SpoilerStripesDrawable;
 import org.joinmastodon.android.model.StatusPrivacy;
 import org.joinmastodon.android.model.TranslatedStatus;
 import org.joinmastodon.android.ui.text.HtmlParser;
@@ -44,6 +49,7 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 	public final Status status;
 	public boolean disableTranslate;
 	public boolean translated = false;
+	public boolean shouldTruncate = true;
 	public TranslatedStatus translation = null;
 	private AccountSession session;
 
@@ -109,9 +115,13 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 
 		@Override
 		public void onBind(TextStatusDisplayItem item){
-			text.setText(item.translated
-							? HtmlParser.parse(item.translation.content, item.status.emojis, item.status.mentions, item.status.tags, item.parentFragment.getAccountID())
-							: item.text);
+			if (item.translated)
+				text.setText(HtmlParser.parse(item.translation.content, item.status.emojis, item.status.mentions, item.status.tags, item.parentFragment.getAccountID()));
+			else if (item.shouldTruncate)
+				text.setText(UiUtils.truncateString(text.getPaint(), item.text));
+			else
+				text.setText(item.text);
+
 			text.setTextIsSelectable(item.textSelectable);
 			spoilerTitleInline.setTextIsSelectable(item.textSelectable);
 			text.setInvalidateOnEveryFrame(false);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
@@ -1,21 +1,13 @@
 package org.joinmastodon.android.ui.displayitems;
 
 import android.app.Activity;
-import android.graphics.Color;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
-import android.text.Spannable;
-import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.TextPaint;
 import android.text.TextUtils;
-import android.text.style.ClickableSpan;
-import android.text.style.ForegroundColorSpan;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.joinmastodon.android.GlobalUserPreferences;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -31,6 +31,7 @@ import android.os.Looper;
 import android.provider.OpenableColumns;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
+import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.HapticFeedbackConstants;
@@ -131,6 +132,7 @@ public class UiUtils {
 	private static Handler mainHandler = new Handler(Looper.getMainLooper());
 	private static final DateTimeFormatter DATE_FORMATTER_SHORT_WITH_YEAR = DateTimeFormatter.ofPattern("d MMM uuuu"), DATE_FORMATTER_SHORT = DateTimeFormatter.ofPattern("d MMM");
 	public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.SHORT);
+	private static final int POST_MAX_CHAR_LENGTH=666;
 
 	private UiUtils() {
 	}
@@ -1175,5 +1177,13 @@ public class UiUtils {
 
 		// fucking finally
 		return container;
+	}
+
+	public static CharSequence truncateString(TextPaint textPaint, CharSequence text) {
+		if (text.length() > POST_MAX_CHAR_LENGTH){
+			float paintLength = textPaint.measureText(text, 0, POST_MAX_CHAR_LENGTH);
+			return TextUtils.ellipsize(text, textPaint, paintLength, TextUtils.TruncateAt.END);
+		}
+		return text;
 	}
 }


### PR DESCRIPTION
Closes #215.

Adds the feature to truncate posts. Post are truncate by default, and can be expanded by tapping on them.

The current maximum posts length before truncating them is set to `666`, the exact length is not important (as it is just a rough estimation of the length), but I set it to a value above the default `500` character limit with a bit of room to spare.
Translate post are not truncate, since it can be safely assumed, if a user translates a post, they want to read the whole post.

https://user-images.githubusercontent.com/63370021/215578650-7408578a-c492-4b82-966a-d881e067ac6f.mp4

This pr is not yet finished, there are probably a couple of places I missed when testing. Also, I wasn't sure if it should be possible to expand a post in the timeline? And how could be integrated into the UI. 