### PR TITLE
fix: disable group divider on EMUI

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -358,7 +358,7 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 		addListsToOverflowMenu();
 		addHashtagsToOverflowMenu();
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && !UiUtils.isEMUI()) {
 			m.setGroupDividerEnabled(true);
 		}
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -1143,6 +1143,10 @@ public class UiUtils {
 		return !TextUtils.isEmpty(getSystemProperty("ro.miui.ui.version.code"));
 	}
 
+	public static boolean isEMUI() {
+		return !TextUtils.isEmpty(getSystemProperty("ro.build.version.emui"));
+	}
+
 	public static int alphaBlendColors(int color1, int color2, float alpha) {
 		float alpha0 = 1f - alpha;
 		int r = Math.round(((color1 >> 16) & 0xFF) * alpha0 + ((color2 >> 16) & 0xFF) * alpha);


### PR DESCRIPTION
Fixes an issue, where the fourth menu item does not show up, when the divider is enabled on EMUI devices.
| Before                                                                                                           	| After                                                                                                           	|
|------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
| ![Before](https://user-images.githubusercontent.com/63370021/224400191-cc28f8e6-b910-4077-95f7-4b82c003764f.png) 	| ![After](https://user-images.githubusercontent.com/63370021/224400198-17e3276a-0389-42f4-9c24-a1741ae99da1.png) 	|