### PR TITLE
feat(welcome): use URI InputType

### DIFF
--- a/mastodon/src/main/res/layout/header_welcome_custom.xml
+++ b/mastodon/src/main/res/layout/header_welcome_custom.xml
@@ -36,7 +36,7 @@
 		android:layout_marginTop="16dp"
 		android:layout_marginBottom="8dp"
 		android:layout_marginHorizontal="16dp"
-		android:inputType="textFilter|textNoSuggestions"
+		android:inputType="textUri|textNoSuggestions"
 		android:singleLine="true"
 		android:imeOptions="actionGo"
 		android:drawableStart="@drawable/ic_fluent_globe_20_regular"


### PR DESCRIPTION
Changes the inputtype of the edittext on the welcome screen to `textUri`. This improves the experience of entering URLs, by adding a dedicated key to the keyboard.