### PR TITLE
Fix crashes on Calckey and GoToSocial

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
@@ -154,8 +154,9 @@ public class NotificationsListFragment extends BaseStatusListFragment<Notificati
 						if(offset==0 && !result.items.isEmpty() && !result.isFromCache()){
 							E.post(new AllNotificationsSeenEvent());
 							new SaveMarkers(null, result.items.get(0).id).exec(accountID);
-							AccountSessionManager.getInstance().getAccount(accountID).markers
-									.notifications.lastReadId = result.items.get(0).id;
+							if (AccountSessionManager.getInstance().getAccount(accountID).markers != null)
+								AccountSessionManager.getInstance().getAccount(accountID).markers
+										.notifications.lastReadId = result.items.get(0).id;
 							AccountSessionManager.getInstance().writeAccountsFile();
 						}
 					}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/MediaGridStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/MediaGridStatusDisplayItem.java
@@ -55,7 +55,7 @@ public class MediaGridStatusDisplayItem extends StatusDisplayItem{
 		for(Attachment att:attachments){
 			requests.add(new UrlImageLoaderRequest(switch(att.type){
 				case IMAGE -> att.url;
-				case VIDEO, GIFV -> att.previewUrl;
+				case VIDEO, GIFV -> att.previewUrl != null ? att.previewUrl : att.url;
 				default -> throw new IllegalStateException("Unexpected value: "+att.type);
 			}, 1000, 1000));
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/utils/MastodonLanguage.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/MastodonLanguage.java
@@ -85,7 +85,7 @@ public class MastodonLanguage {
 		private final MastodonLanguage fallbackLanguage;
 
 		public LanguageResolver(Instance instanceInfo) {
-			String fallbackLanguageTag = !instanceInfo.languages.isEmpty() ? instanceInfo.languages.get(0) : ENGLISH.languageTag;
+			String fallbackLanguageTag = (instanceInfo.languages != null && !instanceInfo.languages.isEmpty()) ? instanceInfo.languages.get(0) : ENGLISH.languageTag;
 			fallbackLanguage = allLanguages.stream()
 					.filter(l->l.languageTag.equalsIgnoreCase(fallbackLanguageTag)).findAny()
 					.orElse(ENGLISH);


### PR DESCRIPTION
Both Calckey and GoToSocial would throw NullPointerExceptions when accessing notificaions. The markers field in the account session would be null and checking that beforehand seems to fix it

GoToSocial would also crash when trying to post because the language info was null