### PR TITLE
feat: show URL in recents

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/DomainManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/DomainManager.java
@@ -1,0 +1,26 @@
+package org.joinmastodon.android;
+
+public class DomainManager {
+    private static final String TAG="DomainManager";
+
+    private static final DomainManager instance=new DomainManager();
+
+    private String currentDomain = "";
+
+
+    public static DomainManager getInstance(){
+        return instance;
+    }
+
+    private DomainManager(){
+
+    }
+
+    public String getCurrentDomain() {
+        return currentDomain;
+    }
+
+    public void setCurrentDomain(String domain) {
+        this.currentDomain = domain;
+    }
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
@@ -2,8 +2,10 @@ package org.joinmastodon.android;
 
 import android.Manifest;
 import android.app.Fragment;
+import android.app.assist.AssistContent;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -94,6 +96,7 @@ public class MainActivity extends FragmentStackActivity{
 				Fragment fragment=new HomeFragment();
 				fragment.setArguments(args);
 				showFragmentClearingBackStack(fragment);
+				DomainManager.getInstance().setCurrentDomain(accountSession.domain);
 			}
 		}else if(intent.getBooleanExtra("compose", false)){
 			showCompose();
@@ -167,4 +170,12 @@ public class MainActivity extends FragmentStackActivity{
 			super.onBackPressed();
 		}
 	}
+
+	@Override
+	public void onProvideAssistContent(AssistContent outContent) {
+		super.onProvideAssistContent(outContent);
+
+		outContent.setWebUri(Uri.parse(DomainManager.getInstance().getCurrentDomain()));
+	}
+
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -68,7 +68,7 @@ import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public abstract class BaseStatusListFragment<T extends DisplayItemsParent> extends RecyclerFragment<T> implements PhotoViewerHost, ScrollableToTop, HasFab{
+public abstract class BaseStatusListFragment<T extends DisplayItemsParent> extends RecyclerFragment<T> implements PhotoViewerHost, ScrollableToTop, HasFab, DomainDisplay{
 	protected ArrayList<StatusDisplayItem> displayItems=new ArrayList<>();
 	protected DisplayItemsAdapter adapter;
 	protected String accountID;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/DomainDisplay.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/DomainDisplay.java
@@ -1,0 +1,15 @@
+package org.joinmastodon.android.fragments;
+
+import org.joinmastodon.android.api.session.AccountSession;
+import org.joinmastodon.android.api.session.AccountSessionManager;
+
+public interface DomainDisplay {
+
+    default String getDomain(){
+        AccountSession session = AccountSessionManager.getInstance().getLastActiveAccount();
+        if (session != null)
+            return session.domain;
+        else
+            return "";
+    }
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.Toast;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.tags.GetHashtag;
@@ -44,11 +45,17 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment {
 	}
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/tags/" + hashtag;
+	}
+
+	@Override
 	public void onAttach(Activity activity){
 		super.onAttach(activity);
 		updateTitle(getArguments().getString("hashtag"));
 		following=getArguments().getBoolean("following", false);
 		setHasOptionsMenu(true);
+		DomainManager.getInstance().setCurrentDomain(getDomain());
 	}
 
 	private void updateTitle(String hashtagName) {

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -16,6 +16,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.notifications.GetNotifications;
@@ -180,6 +181,8 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	@Override
 	public void onHiddenChanged(boolean hidden){
 		super.onHiddenChanged(hidden);
+		if (!hidden && fragmentForTab(currentTab) instanceof  DomainDisplay display)
+			DomainManager.getInstance().setCurrentDomain(display.getDomain());
 		fragmentForTab(currentTab).onHiddenChanged(hidden);
 	}
 
@@ -237,6 +240,10 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		currentTab=tab;
 		((FragmentStackActivity)getActivity()).invalidateSystemBarColors(this);
 		if (tab == R.id.tab_search && isPleroma) searchFragment.selectSearch();
+
+		if (newFragment instanceof DomainDisplay display) {
+			DomainManager.getInstance().setCurrentDomain(display.getDomain());
+		}
 	}
 
 	private void maybeTriggerLoading(Fragment newFragment){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -36,6 +36,7 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.squareup.otto.Subscribe;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
@@ -71,7 +72,7 @@ import me.grishka.appkit.fragments.OnBackPressedListener;
 import me.grishka.appkit.utils.CubicBezierInterpolator;
 import me.grishka.appkit.utils.V;
 
-public class HomeTabFragment extends MastodonToolbarFragment implements ScrollableToTop, OnBackPressedListener, HasFab {
+public class HomeTabFragment extends MastodonToolbarFragment implements ScrollableToTop, OnBackPressedListener, HasFab, DomainDisplay {
 	private static final int ANNOUNCEMENTS_RESULT = 654;
 
 	private String accountID;
@@ -203,6 +204,10 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 				if (fragments[position] instanceof BaseRecyclerFragment<?> page){
 					if(!page.loaded && !page.isDataLoading()) page.loadData();
 				}
+
+				//update recent app list url
+				if (fragments[position] instanceof DomainDisplay page)
+					DomainManager.getInstance().setCurrentDomain(page.getDomain());
 			}
 		});
 
@@ -285,6 +290,15 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 				error.showToast(getActivity());
 			}
 		}).exec(accountID);
+	}
+
+
+	@Override
+	public String getDomain() {
+		if (fragments[pager.getCurrentItem()] instanceof DomainDisplay page) {
+			return page.getDomain();
+		}
+		return DomainDisplay.super.getDomain();
 	}
 
 	private void onFabClick(View v){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
@@ -41,6 +41,11 @@ public class HomeTimelineFragment extends StatusListFragment {
 	}
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/home";
+	}
+
+	@Override
 	public void onAttach(Activity activity){
 		super.onAttach(activity);
 		if (getParentFragment() instanceof HomeTabFragment home) parent = home;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
@@ -13,6 +13,12 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager2.widget.ViewPager2;
+
+import com.squareup.otto.Subscribe;
+
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
@@ -25,19 +31,13 @@ import org.joinmastodon.android.ui.tabs.TabLayout;
 import org.joinmastodon.android.ui.tabs.TabLayoutMediator;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.viewpager2.widget.ViewPager2;
-
-import com.squareup.otto.Subscribe;
-
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
 import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.utils.V;
 
-public class NotificationsFragment extends MastodonToolbarFragment implements ScrollableToTop{
+public class NotificationsFragment extends MastodonToolbarFragment implements ScrollableToTop, DomainDisplay {
 
 	private TabLayout tabLayout;
 	private ViewPager2 pager;
@@ -47,6 +47,11 @@ public class NotificationsFragment extends MastodonToolbarFragment implements Sc
 	private NotificationsListFragment allNotificationsFragment, mentionsFragment;
 
 	private String accountID;
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/notifications";
+	}
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -42,6 +42,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.accounts.GetAccountByID;
@@ -204,6 +205,14 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 	public void onAttach(Activity activity){
 		super.onAttach(activity);
 		setHasOptionsMenu(true);
+	}
+
+	@Override
+	public void onHiddenChanged(boolean hidden) {
+		super.onHiddenChanged(hidden);
+		if (!hidden) {
+			DomainManager.getInstance().setCurrentDomain(account.url);
+		}
 	}
 
 	@Override
@@ -761,6 +770,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		followsYouView.setVisibility(relationship.followedBy ? View.VISIBLE : View.GONE);
 		notifyButton.setSelected(relationship.notifying);
 		notifyButton.setContentDescription(getString(relationship.notifying ? R.string.sk_user_post_notifications_on : R.string.sk_user_post_notifications_off, '@'+account.username));
+		DomainManager.getInstance().setCurrentDomain(account.url);
 	}
 
 	public ImageButton getFab() {

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import androidx.recyclerview.widget.RecyclerView;
 import me.grishka.appkit.Nav;
 
-public abstract class StatusListFragment extends BaseStatusListFragment<Status>{
+public abstract class StatusListFragment extends BaseStatusListFragment<Status> implements DomainDisplay{
 	protected EventListener eventListener=new EventListener();
 
 	protected List<StatusDisplayItem> buildDisplayItems(Status s){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
@@ -3,6 +3,7 @@ package org.joinmastodon.android.fragments;
 import android.os.Bundle;
 import android.view.View;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.statuses.GetStatusContext;
 import org.joinmastodon.android.api.session.AccountSession;
@@ -29,8 +30,13 @@ import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.SimpleCallback;
 
-public class ThreadFragment extends StatusListFragment{
+public class ThreadFragment extends StatusListFragment implements DomainDisplay{
 	protected Status mainStatus;
+
+	@Override
+	public String getDomain() {
+		return mainStatus.url;
+	}
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -42,6 +48,7 @@ public class ThreadFragment extends StatusListFragment{
 		data.add(mainStatus);
 		onAppendItems(Collections.singletonList(mainStatus));
 		setTitle(HtmlParser.parseCustomEmoji(getString(R.string.post_from_user, mainStatus.account.displayName), mainStatus.account.emojis));
+		DomainManager.getInstance().setCurrentDomain(getDomain());
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverAccountsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverAccountsFragment.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.accounts.GetAccountRelationships;
 import org.joinmastodon.android.api.requests.accounts.GetFollowSuggestions;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ProfileFragment;
 import org.joinmastodon.android.fragments.RecyclerFragment;
@@ -49,13 +50,18 @@ import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class DiscoverAccountsFragment extends RecyclerFragment<DiscoverAccountsFragment.AccountWrapper> implements ScrollableToTop, IsOnTop {
+public class DiscoverAccountsFragment extends RecyclerFragment<DiscoverAccountsFragment.AccountWrapper> implements ScrollableToTop, IsOnTop, DomainDisplay {
 	private String accountID;
 	private Map<String, Relationship> relationships=Collections.emptyMap();
 	private GetAccountRelationships relationshipsRequest;
 
 	public DiscoverAccountsFragment(){
 		super(20);
+	}
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/explore/suggestions";
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -17,8 +17,10 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.HomeFragment;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
@@ -37,7 +39,7 @@ import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.fragments.OnBackPressedListener;
 import me.grishka.appkit.utils.V;
 
-public class DiscoverFragment extends AppKitFragment implements ScrollableToTop, OnBackPressedListener, IsOnTop {
+public class DiscoverFragment extends AppKitFragment implements ScrollableToTop, OnBackPressedListener, IsOnTop, DomainDisplay {
 
 	private TabLayout tabLayout;
 	private ViewPager2 pager;
@@ -65,6 +67,18 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 			setRetainInstance(true);
 
 		accountID=getArguments().getString("account");
+	}
+
+
+	@Override
+	public String getDomain() {
+		if (searchActive) {
+			return searchFragment.getDomain();
+		}
+		if (tabViews[tabLayout.getSelectedTabPosition()] instanceof DomainDisplay page) {
+			return page.getDomain();
+		}
+		return DomainDisplay.super.getDomain() + "/explore";
 	}
 
 	@Nullable
@@ -107,6 +121,10 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 					if(!page.loaded && !page.isDataLoading())
 						page.loadData();
 				}
+
+
+				if (_page instanceof DomainDisplay display)
+					DomainManager.getInstance().setCurrentDomain(display.getDomain());
 			}
 		});
 
@@ -152,7 +170,9 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 		tabLayoutMediator.attach();
 		tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener(){
 			@Override
-			public void onTabSelected(TabLayout.Tab tab){}
+			public void onTabSelected(TabLayout.Tab tab){
+				DomainManager.getInstance().setCurrentDomain(getDomain());
+			}
 
 			@Override
 			public void onTabUnselected(TabLayout.Tab tab){}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.trends.GetTrendingLinks;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.RecyclerFragment;
 import org.joinmastodon.android.fragments.ScrollableToTop;
@@ -35,13 +36,18 @@ import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class DiscoverNewsFragment extends RecyclerFragment<Card> implements ScrollableToTop, IsOnTop {
+public class DiscoverNewsFragment extends RecyclerFragment<Card> implements ScrollableToTop, IsOnTop, DomainDisplay {
 	private String accountID;
 	private List<ImageLoaderRequest> imageRequests=Collections.emptyList();
 	private DiscoverInfoBannerHelper bannerHelper=new DiscoverInfoBannerHelper(DiscoverInfoBannerHelper.BannerType.TRENDING_LINKS);
 
 	public DiscoverNewsFragment(){
 		super(10);
+	}
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/explore/links";
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverPostsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverPostsFragment.java
@@ -20,6 +20,12 @@ public class DiscoverPostsFragment extends StatusListFragment implements IsOnTop
 	private DiscoverInfoBannerHelper bannerHelper=new DiscoverInfoBannerHelper(DiscoverInfoBannerHelper.BannerType.TRENDING_POSTS);
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/explore/posts";
+	}
+
+
+	@Override
 	protected void doLoadData(int offset, int count){
 		currentRequest=new GetTrendingStatuses(offset, count)
 				.setCallback(new SimpleCallback<>(this){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/FederatedTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/FederatedTimelineFragment.java
@@ -25,6 +25,10 @@ public class FederatedTimelineFragment extends StatusListFragment {
 		return true;
 	}
 
+	@Override
+	public String getDomain() {
+		return super.getDomain() + "/public";
+	}
 
 	@Override
 	protected void doLoadData(int offset, int count){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/LocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/LocalTimelineFragment.java
@@ -24,6 +24,10 @@ public class LocalTimelineFragment extends StatusListFragment {
 		return true;
 	}
 
+	@Override
+	public String getDomain() {
+		return super.getDomain() + "/public/local";
+	}
 
 	@Override
 	protected void doLoadData(int offset, int count){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
@@ -11,6 +11,7 @@ import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.search.GetSearchResults;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ProfileFragment;
 import org.joinmastodon.android.fragments.ThreadFragment;
@@ -42,7 +43,7 @@ import me.grishka.appkit.api.ErrorResponse;
 import me.grishka.appkit.utils.MergeRecyclerAdapter;
 import me.grishka.appkit.utils.V;
 
-public class SearchFragment extends BaseStatusListFragment<SearchResult> implements IsOnTop {
+public class SearchFragment extends BaseStatusListFragment<SearchResult> implements IsOnTop, DomainDisplay {
 	private String currentQuery;
 	private List<StatusDisplayItem> prevDisplayItems;
 	private EnumSet<SearchResult.Type> currentFilter=EnumSet.allOf(SearchResult.Type.class);
@@ -55,6 +56,11 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult> impleme
 
 	public SearchFragment(){
 		setLayout(R.layout.fragment_search);
+	}
+
+	@Override
+	public String getDomain() {
+		return super.getDomain() + "/search";
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.trends.GetTrendingHashtags;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.RecyclerFragment;
 import org.joinmastodon.android.fragments.ScrollableToTop;
@@ -27,7 +28,7 @@ import me.grishka.appkit.api.SimpleCallback;
 import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class TrendingHashtagsFragment extends RecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop {
+public class TrendingHashtagsFragment extends RecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop, DomainDisplay {
 	private String accountID;
 	private DiscoverInfoBannerHelper bannerHelper=new DiscoverInfoBannerHelper(DiscoverInfoBannerHelper.BannerType.TRENDING_HASHTAGS);
 
@@ -39,6 +40,11 @@ public class TrendingHashtagsFragment extends RecyclerFragment<Hashtag> implemen
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
 		accountID=getArguments().getString("account");
+	}
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/explore/tags";
 	}
 
 	@Override


### PR DESCRIPTION
Upstreaming https://github.com/LucasGGamerM/moshidon/pull/120, showing the web-equivalent URL of the current screen in the recent screen (pixel only).

![Recent screen with post URL](https://github.com/sk22/megalodon/assets/63370021/4f859149-9875-408f-975f-92cb5900487e)
