### PR TITLE
feat: share to open url

### DIFF
--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -62,7 +62,8 @@
 				<data android:scheme="megalodon-android-auth" android:host="callback"/>
 			</intent-filter>
 		</activity>
-		<activity android:name=".ExternalShareActivity" android:exported="true" android:configChanges="orientation|screenSize" android:windowSoftInputMode="adjustResize">
+		<activity android:name=".ExternalShareActivity" android:exported="true" android:configChanges="orientation|screenSize" android:windowSoftInputMode="adjustResize"
+			android:theme="@style/TransparentDialog">
 			<intent-filter>
 				<action android:name="android.intent.action.SEND"/>
 				<category android:name="android.intent.category.DEFAULT"/>

--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -11,6 +11,7 @@ import android.widget.Toast;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.ComposeFragment;
+import org.joinmastodon.android.ui.AccountSwitcherSheet;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.jsoup.internal.StringUtil;
 
@@ -34,10 +35,7 @@ public class ExternalShareActivity extends FragmentStackActivity{
 			}else if(sessions.size()==1){
 				openComposeFragment(sessions.get(0).getID());
 			}else{
-				UiUtils.pickAccount(this, null, R.string.choose_account, 0,
-						session -> openComposeFragment(session.getID()),
-						b -> b.setOnCancelListener(d -> finish())
-				);
+				new AccountSwitcherSheet(this, false, false, accountSession -> openComposeFragment(accountSession.getID())).show();
 			}
 		}
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -3,7 +3,6 @@ package org.joinmastodon.android;
 import android.app.Fragment;
 import android.content.ClipData;
 import android.content.Intent;
-import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -35,7 +34,6 @@ public class ExternalShareActivity extends FragmentStackActivity{
 			}else if(sessions.size()==1){
 				openComposeFragment(sessions.get(0).getID());
 			}else{
-				getWindow().setBackgroundDrawable(new ColorDrawable(0xff000000));
 				UiUtils.pickAccount(this, null, R.string.choose_account, 0,
 						session -> openComposeFragment(session.getID()),
 						b -> b.setOnCancelListener(d -> finish())

--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -28,14 +28,23 @@ public class ExternalShareActivity extends FragmentStackActivity{
 		UiUtils.setUserPreferredTheme(this);
 		super.onCreate(savedInstanceState);
 		if(savedInstanceState==null){
+
+			String text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+			boolean isMastodonURL = UiUtils.looksLikeMastodonUrl(text);
+
 			List<AccountSession> sessions=AccountSessionManager.getInstance().getLoggedInAccounts();
 			if(sessions.isEmpty()){
 				Toast.makeText(this, R.string.err_not_logged_in, Toast.LENGTH_SHORT).show();
 				finish();
-			}else if(sessions.size()==1){
+			}else if(sessions.size()==1 && !isMastodonURL){
 				openComposeFragment(sessions.get(0).getID());
 			}else{
-				new AccountSwitcherSheet(this, false, false, accountSession -> openComposeFragment(accountSession.getID())).show();
+				new AccountSwitcherSheet(this, false, false, isMastodonURL, accountSession -> {
+					if(accountSession!=null)
+						openComposeFragment(accountSession.getID());
+					else
+						UiUtils.openURL(this, AccountSessionManager.getInstance().getLastActiveAccountID(), text);
+				}).show();
 			}
 		}
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -265,7 +265,7 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			for(AccountSession session:AccountSessionManager.getInstance().getLoggedInAccounts()){
 				options.add(session.self.displayName+"\n("+session.self.username+"@"+session.domain+")");
 			}
-			new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+			new AccountSwitcherSheet(getActivity(), true, true, false, accountSession -> {
 				getActivity().finish();
 				getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
 			}).show();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -2,6 +2,7 @@ package org.joinmastodon.android.fragments;
 
 import android.app.Fragment;
 import android.app.NotificationManager;
+import android.content.Intent;
 import android.graphics.Outline;
 import android.os.Build;
 import android.os.Bundle;
@@ -16,7 +17,13 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
+import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
+
+import com.squareup.otto.Subscribe;
+
 import org.joinmastodon.android.E;
+import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.notifications.GetNotifications;
 import org.joinmastodon.android.api.session.AccountSession;
@@ -35,11 +42,6 @@ import org.parceler.Parcels;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-
-import androidx.annotation.IdRes;
-import androidx.annotation.Nullable;
-
-import com.squareup.otto.Subscribe;
 
 import me.grishka.appkit.FragmentStackActivity;
 import me.grishka.appkit.api.Callback;
@@ -263,7 +265,10 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			for(AccountSession session:AccountSessionManager.getInstance().getLoggedInAccounts()){
 				options.add(session.self.displayName+"\n("+session.self.username+"@"+session.domain+")");
 			}
-			new AccountSwitcherSheet(getActivity()).show();
+			new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+				getActivity().finish();
+				getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
+			}).show();
 			return true;
 		}
 		return false;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -85,13 +85,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
-import androidx.viewpager2.widget.ViewPager2;
+
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -85,9 +85,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import androidx.viewpager2.widget.ViewPager2;
 
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
@@ -110,7 +110,10 @@ public class AccountActivationFragment extends ToolbarFragment{
 
 	@Override
 	public void onToolbarNavigationClick(){
-		new AccountSwitcherSheet(getActivity()).show();
+		new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+			getActivity().finish();
+			getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
+		}).show();
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
@@ -110,7 +110,7 @@ public class AccountActivationFragment extends ToolbarFragment{
 
 	@Override
 	public void onToolbarNavigationClick(){
-		new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+		new AccountSwitcherSheet(getActivity(), true, true, false, accountSession -> {
 			getActivity().finish();
 			getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
 		}).show();

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Animatable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -25,6 +26,7 @@ import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
 import org.joinmastodon.android.ui.utils.UiUtils;
+import org.w3c.dom.Text;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -79,7 +81,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 			AccountViewHolder holder = new AccountViewHolder();
 			holder.more.setVisibility(View.GONE);
 			holder.currentIcon.setVisibility(View.GONE);
-			holder.name.setText(R.string.add_account);
+			holder.display_name.setVisibility(View.GONE);
+			holder.display_add_account.setVisibility(View.VISIBLE);
 			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
 			holder.avatar.setImageResource(R.drawable.ic_fluent_add_circle_24_filled);
 			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
@@ -183,6 +186,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 
 	private class AccountViewHolder extends BindableViewHolder<AccountSession> implements ImageLoaderViewHolder, UsableRecyclerView.Clickable{
 		private final TextView name;
+		private final TextView display_name;
+		private final TextView display_add_account;
 		private final ImageView avatar;
 		private final ImageButton more;
 		private final View currentIcon;
@@ -191,6 +196,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 		public AccountViewHolder(){
 			super(activity, R.layout.item_account_switcher, list);
 			name=findViewById(R.id.name);
+			display_name=findViewById(R.id.display_name);
+			display_add_account=findViewById(R.id.add_account);
 			avatar=findViewById(R.id.avatar);
 			more=findViewById(R.id.more);
 			currentIcon=findViewById(R.id.current);
@@ -210,6 +217,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 		@SuppressLint("SetTextI18n")
 		@Override
 		public void onBind(AccountSession item){
+			display_name.setText(item.self.displayName);
 			name.setText("@"+item.self.username+"@"+item.domain);
 			if(AccountSessionManager.getInstance().getLastActiveAccountID().equals(item.getID())){
 				more.setVisibility(View.GONE);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
@@ -2,13 +2,11 @@ package org.joinmastodon.android.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -18,22 +16,21 @@ import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
 import org.joinmastodon.android.GlobalUserPreferences;
-import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.oauth.RevokeOauthToken;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
 import org.joinmastodon.android.ui.utils.UiUtils;
-import org.w3c.dom.Text;
 
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.LinearLayoutManager;
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
@@ -58,7 +55,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 	private final boolean logOutEnabled;
 	private final Consumer<AccountSession> onClick;
 
-	public AccountSwitcherSheet(@NonNull Activity activity, boolean logOutEnabled, boolean addAccountEnabled, Consumer<AccountSession> onClick){
+	public AccountSwitcherSheet(@NonNull Activity activity, boolean logOutEnabled, boolean addAccountEnabled, boolean showOpenURL, Consumer<AccountSession> onClick){
 		super(activity);
 		this.activity=activity;
 		this.logOutEnabled=logOutEnabled;
@@ -88,6 +85,22 @@ public class AccountSwitcherSheet extends BottomSheet{
 			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
 			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {
 				Nav.go(activity, CustomWelcomeFragment.class, null);
+				dismiss();
+			}));
+		}
+
+		if(showOpenURL) {
+			AccountViewHolder holder = new AccountViewHolder();
+			holder.more.setVisibility(View.GONE);
+			holder.currentIcon.setVisibility(View.GONE);
+			holder.display_name.setVisibility(View.VISIBLE);
+			holder.display_add_account.setVisibility(View.VISIBLE);
+			holder.display_add_account.setText(R.string.sk_share_open_url);
+			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
+			holder.avatar.setImageResource(R.drawable.ic_fluent_open_24_regular);
+			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
+			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {
+				onClick.accept(null);
 				dismiss();
 			}));
 		}

--- a/mastodon/src/main/res/layout/item_account_switcher.xml
+++ b/mastodon/src/main/res/layout/item_account_switcher.xml
@@ -2,27 +2,62 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:orientation="horizontal"
 	android:layout_width="match_parent"
-	android:layout_height="48dp"
+	android:layout_height="52dp"
 	android:paddingLeft="20dp"
 	android:paddingRight="20dp"
 	android:gravity="center_vertical">
 	
 	<ImageView
 		android:id="@+id/avatar"
-		android:layout_width="32dp"
-		android:layout_height="32dp"
+		android:layout_width="36dp"
+		android:layout_height="36dp"
 		android:importantForAccessibility="no"/>
 
+	<LinearLayout
+		android:orientation="vertical"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content">
+
+		<TextView
+			android:id="@+id/display_name"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:layout_marginStart="24dp"
+			android:textSize="16sp"
+			android:textColor="?android:textColorPrimary"
+			android:singleLine="true"
+			android:ellipsize="end"/>
+
+		<TextView
+			android:id="@+id/name"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:layout_marginStart="24dp"
+			android:textSize="14sp"
+			android:textColor="?android:textColorSecondary"
+			android:singleLine="true"
+			android:ellipsize="end"/>
+
+	</LinearLayout>
+
 	<TextView
-		android:id="@+id/name"
+		android:id="@+id/add_account"
 		android:layout_width="0dp"
 		android:layout_height="wrap_content"
 		android:layout_weight="1"
-		android:layout_marginStart="24dp"
 		android:textSize="16sp"
 		android:textColor="?android:textColorPrimary"
+		android:text="@string/add_account"
 		android:singleLine="true"
+		android:visibility="gone"
 		android:ellipsize="end"/>
+
+	<Space
+		android:layout_width="0px"
+		android:layout_height="1px"
+		android:layout_weight="1"/>
 
 	<View
 		android:id="@+id/current"

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -288,4 +288,5 @@
     <string name="sk_settings_content_types_explanation">Allows setting a content type like Markdown when creating a post. Keep in mind that not all instances support this.</string>
     <string name="sk_settings_default_content_type">Default content type</string>
     <string name="sk_settings_default_content_type_explanation">This lets you have a content type be pre-selected when creating new posts, overriding the value set in “Posting preferences”.</string>
+    <string name="sk_share_open_url">Open in App</string>
 </resources>

--- a/mastodon/src/main/res/values/styles.xml
+++ b/mastodon/src/main/res/values/styles.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+
+	<style name="TransparentDialog" parent="android:Theme.Dialog">
+	<item name="android:windowIsTranslucent">true</item>
+	<item name="android:windowBackground">@android:color/transparent</item>
+	<item name="android:windowContentOverlay">@null</item>
+	<item name="android:windowNoTitle">true</item>
+	<item name="android:windowIsFloating">true</item>
+	<item name="android:backgroundDimEnabled">false</item>
+	</style>
+
 	<style name="Theme.Mastodon.Light" parent="Theme.AppKit.Light">
 		<!-- needed to disable scrim on API 29+ -->
 		<item name="android:enforceNavigationBarContrast" tools:ignore="NewApi">false</item>


### PR DESCRIPTION
Upstreams https://github.com/LucasGGamerM/moshidon/pull/125 (which depends on https://github.com/LucasGGamerM/moshidon/pull/121).

This redesign the share dialog to be use the  `AccountSwitcherSheet`. It then adds a new option to open shared URLs directly in the app. The option will only be visible when the URL is a Mastodon URL.

![Share Sheet with option to open in app](https://github.com/sk22/megalodon/assets/63370021/d3d82174-01b9-4dd5-9255-3432787ade3e)
