### PR TITLE
feat: load following/followers from other instances

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/GetAccountByHandle.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/GetAccountByHandle.java
@@ -1,0 +1,11 @@
+package org.joinmastodon.android.api.requests.accounts;
+
+import org.joinmastodon.android.api.MastodonAPIRequest;
+import org.joinmastodon.android.model.Account;
+
+public class GetAccountByHandle extends MastodonAPIRequest<Account>{
+    public GetAccountByHandle(String acct){
+        super(HttpMethod.GET, "/accounts/lookup", Account.class);
+        addQueryParameter("acct", acct);
+    }
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
@@ -267,6 +267,15 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 
 		@Override
 		public void onClick(){
+			if(item.account.reloadWhenClicked){
+				UiUtils.lookupAccount(getContext(), item.account, accountID, null, account -> {
+					Bundle args=new Bundle();
+					args.putString("account", accountID);
+					args.putParcelable("profileAccount", Parcels.wrap(account));
+					Nav.go(getActivity(), ProfileFragment.class, args);
+				});
+				return;
+			}
 			Bundle args=new Bundle();
 			args.putString("account", accountID);
 			args.putParcelable("profileAccount", Parcels.wrap(item.account));

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
@@ -77,7 +77,10 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 		if(refreshing){
 			relationships.clear();
 		}
-		loadRelationships(d);
+		if(!d.isEmpty() && !d.get(0).account.reloadWhenClicked){
+			loadRelationships(d);
+		}
+
 		super.onDataLoaded(d, more);
 	}
 
@@ -240,7 +243,12 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 		public void bindRelationship(){
 			Relationship rel=relationships.get(item.account.id);
 			if(rel==null || AccountSessionManager.getInstance().isSelf(accountID, item.account)){
-				button.setVisibility(View.GONE);
+				if(item.account.reloadWhenClicked){
+					button.setVisibility(View.VISIBLE);
+					button.setText(R.string.button_follow);
+				} else {
+					button.setVisibility(View.GONE);
+				}
 			}else{
 				button.setVisibility(View.VISIBLE);
 				UiUtils.setRelationshipToActionButton(rel, button);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
@@ -77,7 +77,7 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 		if(refreshing){
 			relationships.clear();
 		}
-		if(!d.isEmpty() && !d.get(0).account.reloadWhenClicked){
+		if(!d.isEmpty() && !d.get(0).account.remoteAccount){
 			loadRelationships(d);
 		}
 
@@ -243,7 +243,7 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 		public void bindRelationship(){
 			Relationship rel=relationships.get(item.account.id);
 			if(rel==null || AccountSessionManager.getInstance().isSelf(accountID, item.account)){
-				if(item.account.reloadWhenClicked){
+				if(item.account.remoteAccount){
 					button.setVisibility(View.VISIBLE);
 					button.setText(R.string.button_follow);
 				} else {
@@ -275,7 +275,7 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 
 		@Override
 		public void onClick(){
-			if(item.account.reloadWhenClicked){
+			if(item.account.remoteAccount){
 				UiUtils.lookupAccount(getContext(), item.account, accountID, null, account -> {
 					Bundle args=new Bundle();
 					args.putString("account", accountID);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowerListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowerListFragment.java
@@ -12,11 +12,17 @@ public class FollowerListFragment extends AccountRelatedAccountListFragment{
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
+		targetAccount = account;
 		setSubtitle(getResources().getQuantityString(R.plurals.x_followers, (int)(account.followersCount%1000), account.followersCount));
 	}
 
 	@Override
 	public HeaderPaginationRequest<Account> onCreateRequest(String maxID, int count){
 		return new GetAccountFollowers(account.id, maxID, count);
+	}
+
+	@Override
+	public HeaderPaginationRequest<Account> onCreateRemoteRequest(String id, String maxID, int count){
+		return new GetAccountFollowers(id, maxID, count);
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowingListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/FollowingListFragment.java
@@ -12,11 +12,17 @@ public class FollowingListFragment extends AccountRelatedAccountListFragment{
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
+		targetAccount = account;
 		setSubtitle(getResources().getQuantityString(R.plurals.x_following, (int)(account.followingCount%1000), account.followingCount));
 	}
 
 	@Override
 	public HeaderPaginationRequest<Account> onCreateRequest(String maxID, int count){
 		return new GetAccountFollowing(account.id, maxID, count);
+	}
+
+	@Override
+	public HeaderPaginationRequest<Account> onCreateRemoteRequest(String id, String maxID, int count){
+		return new GetAccountFollowing(id, maxID, count);
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -1,20 +1,51 @@
 package org.joinmastodon.android.fragments.account_list;
 
+import android.net.Uri;
+
 import org.joinmastodon.android.api.requests.HeaderPaginationRequest;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.HeaderPaginationList;
+import org.joinmastodon.android.ui.utils.UiUtils;
 
 import java.util.stream.Collectors;
 
+import me.grishka.appkit.api.Callback;
+import me.grishka.appkit.api.ErrorResponse;
 import me.grishka.appkit.api.SimpleCallback;
 
 public abstract class PaginatedAccountListFragment extends BaseAccountListFragment{
 	private String nextMaxID;
 
+	protected Account targetAccount;
+
 	public abstract HeaderPaginationRequest<Account> onCreateRequest(String maxID, int count);
+
+	public abstract HeaderPaginationRequest<Account> onCreateRemoteRequest(String id, String maxID, int count);
 
 	@Override
 	protected void doLoadData(int offset, int count){
+		if (shouldLoadRemote()) {
+				UiUtils.lookupRemoteAccount(getContext(), targetAccount, accountID, null, account -> {
+					if(account != null){
+						loadRemoteFollower(offset, count, account);
+					} else {
+						loadFollower(offset, count);
+					}
+				});
+		} else {
+			loadFollower(offset, count);
+		}
+	}
+
+	private boolean shouldLoadRemote() {
+		if (this instanceof FollowingListFragment || this instanceof FollowerListFragment) {
+			return false;
+		}
+		return targetAccount != null && targetAccount.getDomain() != null;
+	}
+
+	void loadFollower(int offset, int count) {
 		currentRequest=onCreateRequest(offset==0 ? null : nextMaxID, count)
 				.setCallback(new SimpleCallback<>(this){
 					@Override
@@ -23,11 +54,40 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 							nextMaxID=result.nextPageUri.getQueryParameter("max_id");
 						else
 							nextMaxID=null;
-						if (getActivity() == null) return;
 						onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), nextMaxID!=null);
 					}
 				})
 				.exec(accountID);
+	}
+
+	private void loadRemoteFollower(int offset, int count, Account account) {
+		String ownDomain = AccountSessionManager.getInstance().getLastActiveAccount().domain;
+		currentRequest=onCreateRemoteRequest(account.id, offset==0 ? null : nextMaxID, count)
+				.setCallback(new Callback<>(){
+					@Override
+					public void onSuccess(HeaderPaginationList<Account> result){
+						if(result.nextPageUri!=null)
+							nextMaxID=result.nextPageUri.getQueryParameter("max_id");
+						else
+							nextMaxID=null;
+						result.stream().forEach(remoteAccount -> {
+							remoteAccount.remoteAccount = true;
+							if (remoteAccount.getDomain() == null) {
+								remoteAccount.acct += "@" + Uri.parse(remoteAccount.url).getHost();
+							} else if (remoteAccount.getDomain().equals(ownDomain)) {
+								remoteAccount.acct = remoteAccount.username;
+							}
+						});
+						onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), nextMaxID!=null);
+					}
+
+					@Override
+					public void onError(ErrorResponse error) {
+						error.showToast(getContext());
+						loadFollower(offset, count);
+					}
+				})
+				.execNoAuth(targetAccount.getDomain());
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -39,7 +39,7 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 	}
 
 	private boolean shouldLoadRemote() {
-		if (this instanceof FollowingListFragment || this instanceof FollowerListFragment) {
+		if (!(this instanceof FollowingListFragment || this instanceof FollowerListFragment)) {
 			return false;
 		}
 		return targetAccount != null && targetAccount.getDomain() != null;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/StatusFavoritesListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/StatusFavoritesListFragment.java
@@ -18,4 +18,9 @@ public class StatusFavoritesListFragment extends StatusRelatedAccountListFragmen
 	public HeaderPaginationRequest<Account> onCreateRequest(String maxID, int count){
 		return new GetStatusFavorites(status.id, maxID, count);
 	}
+
+	@Override
+	public HeaderPaginationRequest<Account> onCreateRemoteRequest(String id, String maxID, int count) {
+		return null;
+	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/StatusReblogsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/StatusReblogsListFragment.java
@@ -18,4 +18,9 @@ public class StatusReblogsListFragment extends StatusRelatedAccountListFragment{
 	public HeaderPaginationRequest<Account> onCreateRequest(String maxID, int count){
 		return new GetStatusReblogs(status.id, maxID, count);
 	}
+
+	@Override
+	public HeaderPaginationRequest<Account> onCreateRemoteRequest(String id, String maxID, int count) {
+		return null;
+	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
@@ -135,6 +135,12 @@ public class Account extends BaseModel implements Searchable{
 
 	public List<Role> roles;
 
+	/**
+	 * Indicate that account data may be wrong and needs to be re-fetched .
+	 * This is the case for accounts from other instances, which contain false (local) ids.
+	 */
+	public boolean remoteAccount;
+
 	@Override
 	public String getQuery() {
 		return url;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -719,6 +719,33 @@ public class UiUtils {
 	}
 
 	public static void performAccountAction(Activity activity, Account account, String accountID, Relationship relationship, Button button, Consumer<Boolean> progressCallback, Consumer<Relationship> resultCallback) {
+		if(relationship == null){
+			UiUtils.lookupAccount(button.getContext(), account, accountID, null, account1 -> {
+				if(account1 == null){
+					return;
+				}
+				progressCallback.accept(true);
+				new SetAccountFollowed(account1.id, true, true, false)
+						.setCallback(new Callback<>(){
+							@Override
+							public void onSuccess(Relationship result){
+								resultCallback.accept(result);
+								progressCallback.accept(false);
+								if(!result.following && !result.requested){
+									E.post(new RemoveAccountPostsEvent(accountID, account.id, true));
+								}
+							}
+
+							@Override
+							public void onError(ErrorResponse error){
+								error.showToast(activity);
+								progressCallback.accept(false);
+							}
+						})
+						.exec(accountID);
+			});
+			return;
+		}
 		if (relationship.blocking) {
 			confirmToggleBlockUser(activity, accountID, account, true, resultCallback);
 		} else if (relationship.muting) {


### PR DESCRIPTION
Port of the Moshidon feature to load followers from other instances. This code was mainly done by @LucasGGamerM, I just slightly refactored his implementation before release.

As the commits were spread over a longer period of time, with different commits in between, I didn't cherry-pick, I just re-implemented his code, it's probably a good idea if he could review this code before merging it, to make sure I didn't miss any important feature/bug fixes.

The implementation is Moshidon also contains a setting to disable this feature, which I did not implement, because I did not think it was necessary. I needed, I can add it as well.