### PR TITLE
fix(edit-timelines/hashtags): set tags as list

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -242,10 +242,14 @@ public class EditTimelinesFragment extends RecyclerFragment<TimelineDefinition> 
     }
 
     private NachoTextView prepareChipTextView(NachoTextView nacho) {
-        nacho.addChipTerminator(',', BEHAVIOR_CHIPIFY_ALL);
-        nacho.addChipTerminator('\n', BEHAVIOR_CHIPIFY_ALL);
-        nacho.addChipTerminator(' ', BEHAVIOR_CHIPIFY_ALL);
-        nacho.addChipTerminator(';', BEHAVIOR_CHIPIFY_ALL);
+        nacho.setChipTerminators(
+                Map.of(
+                        ',', BEHAVIOR_CHIPIFY_ALL,
+                        '\n', BEHAVIOR_CHIPIFY_ALL,
+                        ' ', BEHAVIOR_CHIPIFY_ALL,
+                        ';', BEHAVIOR_CHIPIFY_ALL
+                )
+        );
         nacho.enableEditChipOnTouch(true, true);
         nacho.setOnFocusChangeListener((v, hasFocus) -> nacho.chipifyAllUnterminatedTokens());
         return nacho;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -242,6 +242,7 @@ public class EditTimelinesFragment extends RecyclerFragment<TimelineDefinition> 
     }
 
     private NachoTextView prepareChipTextView(NachoTextView nacho) {
+         //I’ll Be Back
         nacho.setChipTerminators(
                 Map.of(
                         ',', BEHAVIOR_CHIPIFY_ALL,

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -236,7 +236,7 @@ public class EditTimelinesFragment extends RecyclerFragment<TimelineDefinition> 
 
     private boolean setTagListContent(NachoTextView editText, @Nullable List<String> tags) {
         if (tags == null || tags.isEmpty()) return false;
-        editText.setText(String.join(",", tags));
+        editText.setText(tags);
         editText.chipifyAllUnterminatedTokens();
         return true;
     }


### PR DESCRIPTION
Fixes https://github.com/sk22/megalodon/issues/595, by setting the chips as a list of tags and not a singular tag.

| Before                                                                                                          	| After                                                                                                            	|
|-----------------------------------------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------------	|
| ![Tags a singular chip](https://github.com/sk22/megalodon/assets/63370021/fcfb9a16-2bee-4c8a-92e3-d00691333778) 	| ![Tags a multiple chips](https://github.com/sk22/megalodon/assets/63370021/17943d4d-3764-4e57-b300-3545c8c7a7cd) 	|