### PR TITLE
Re-implement some Akkoma specific things + hide filter settings

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -1,7 +1,5 @@
 package org.joinmastodon.android.fragments;
 
-import static org.joinmastodon.android.fragments.ProfileAboutFragment.MAX_FIELDS;
-
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
@@ -175,6 +173,8 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 	private MenuItem editSaveMenuItem;
 	private boolean savingEdits;
 
+	private int maxFields = ProfileAboutFragment.MAX_FIELDS;
+
 	// from ProfileAboutFragment
 	public UsableRecyclerView list;
 	private AboutAdapter adapter;
@@ -200,6 +200,9 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			loaded=true;
 			if(!isOwnProfile)
 				loadRelationship();
+			else if (isInstanceAkkoma()) {
+				maxFields = getInstance().get().pleroma.metadata.fieldsLimits.maxFields;
+			}
 		}else{
 			profileAccountID=getArguments().getString("profileAccountID");
 			if(!getArguments().getBoolean("noAutoLoad", false))
@@ -1385,7 +1388,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		public int getItemCount(){
 			if(isInEditMode){
 				int size=fields.size();
-				if(size<MAX_FIELDS)
+				if(size<maxFields)
 					size++;
 				return size;
 			}
@@ -1510,7 +1513,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		@Override
 		public void onClick(){
 			fields.add(new AccountField());
-			if(fields.size()==MAX_FIELDS){ // replace this row with new row
+			if(fields.size()==maxFields){ // replace this row with new row
 				adapter.notifyItemChanged(fields.size()-1);
 			}else{
 				adapter.notifyItemInserted(fields.size()-1);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -54,6 +54,8 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 	private String accountID;
 	private String currentQuery;
 
+	private boolean disableDiscover;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
@@ -155,6 +157,8 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 			}
 		});
 
+		searchActive = disableDiscover = getArguments().getBoolean("disableDiscover");
+
 		searchView=view.findViewById(R.id.search_fragment);
 		if(searchFragment==null){
 			searchFragment=new SearchFragment();
@@ -171,7 +175,8 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 			if(searchActive) exitSearch(); else openSearch();
 		});
 		if(searchActive){
-			searchBack.setImageResource(R.drawable.ic_fluent_arrow_left_24_regular);
+			if (!TextUtils.isEmpty(currentQuery))
+				searchBack.setImageResource(R.drawable.ic_fluent_arrow_left_24_regular);
 			pager.setVisibility(View.GONE);
 			tabLayout.setVisibility(View.GONE);
 			searchView.setVisibility(View.VISIBLE);
@@ -229,7 +234,7 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 	}
 
 	private void exitSearch(){
-		if(!searchActive)
+		if(!searchActive || disableDiscover)
 			return;
 		searchActive=false;
 		pager.setVisibility(View.VISIBLE);
@@ -255,7 +260,7 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 
 	@Override
 	public boolean onBackPressed(){
-		if(searchActive){
+		if(searchActive && !disableDiscover){
 			exitSearch();
 			return true;
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -157,8 +157,7 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 			}
 		});
 
-		searchActive = disableDiscover = getArguments().getBoolean("disableDiscover");
-
+		disableDiscover=getArguments().getBoolean("disableDiscover");
 		searchView=view.findViewById(R.id.search_fragment);
 		if(searchFragment==null){
 			searchFragment=new SearchFragment();
@@ -174,9 +173,9 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 		searchBack.setOnClickListener(v->{
 			if(searchActive) exitSearch(); else openSearch();
 		});
-		if(searchActive){
-			if (!TextUtils.isEmpty(currentQuery))
-				searchBack.setImageResource(R.drawable.ic_fluent_arrow_left_24_regular);
+		if(searchActive) searchBack.setImageResource(R.drawable.ic_fluent_arrow_left_24_regular);
+		else searchBack.setEnabled(false);
+		if(searchActive || disableDiscover){
 			pager.setVisibility(View.GONE);
 			tabLayout.setVisibility(View.GONE);
 			searchView.setVisibility(View.VISIBLE);
@@ -234,18 +233,21 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 	}
 
 	private void exitSearch(){
-		if(!searchActive || disableDiscover)
+		if(!searchActive)
 			return;
 		searchActive=false;
-		pager.setVisibility(View.VISIBLE);
-		tabLayout.setVisibility(View.VISIBLE);
-		searchView.setVisibility(View.GONE);
 		searchText.setText(R.string.sk_search_fediverse);
 		searchBack.setImageResource(R.drawable.ic_fluent_search_24_regular);
 		searchBack.setEnabled(false);
 		searchBack.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
-		tabsDivider.setVisibility(View.VISIBLE);
 		currentQuery=null;
+		searchFragment.clear();
+
+		if(disableDiscover) return;
+		pager.setVisibility(View.VISIBLE);
+		tabLayout.setVisibility(View.VISIBLE);
+		searchView.setVisibility(View.GONE);
+		tabsDivider.setVisibility(View.VISIBLE);
 	}
 
 	private Fragment getFragmentForPage(int page){
@@ -260,7 +262,7 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 
 	@Override
 	public boolean onBackPressed(){
-		if(searchActive && !disableDiscover){
+		if(searchActive){
 			exitSearch();
 			return true;
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
@@ -54,7 +54,7 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult>{
 		super.onCreate(savedInstanceState);
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N)
 			setRetainInstance(true);
-		setEmptyText(R.string.no_search_results);
+		setEmptyText(R.string.sk_recent_searches_placeholder);
 		loadData();
 	}
 
@@ -173,13 +173,16 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult>{
 	}
 
 	public void setQuery(String q, SearchResult.Type filter){
-		if(q.isBlank())
+		if(q.isBlank()) {
+			setEmptyText(R.string.sk_recent_searches_placeholder);
 			return;
+		}
 		if(currentRequest!=null){
 			currentRequest.cancel();
 			currentRequest=null;
 		}
 		currentQuery=q;
+		setEmptyText(R.string.no_search_results);
 		if(filter==null)
 			currentFilter=EnumSet.allOf(SearchResult.Type.class);
 		else

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
@@ -224,6 +224,13 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult>{
 		}
 	}
 
+	public void clear() {
+		data.clear();
+		preloadedData.clear();
+		adapter.notifyDataSetChanged();
+		V.setVisibilityAnimated(content, View.GONE);
+	}
+
 	@Override
 	public Uri getWebUri(Uri.Builder base) {
 		Uri.Builder searchUri = base.path("/search");

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -3,6 +3,7 @@ package org.joinmastodon.android.ui.displayitems;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -30,6 +31,7 @@ import org.joinmastodon.android.model.ScheduledStatus;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.ui.PhotoLayoutHelper;
 import org.joinmastodon.android.ui.text.HtmlParser;
+import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.ui.viewholders.AccountViewHolder;
 import org.joinmastodon.android.utils.StatusFilterPredicate;
 import org.parceler.Parcels;
@@ -253,6 +255,12 @@ public abstract class StatusDisplayItem{
 
 		List<Attachment> imageAttachments=statusForContent.mediaAttachments.stream().filter(att->att.type.isImage()).collect(Collectors.toList());
 		if(!imageAttachments.isEmpty()){
+			int color = UiUtils.getThemeColor(fragment.getContext(), R.attr.colorM3SurfaceVariant);
+			for (Attachment att : imageAttachments) {
+				if (att.blurhashPlaceholder == null) {
+					att.blurhashPlaceholder = new ColorDrawable(color);
+				}
+			}
 			PhotoLayoutHelper.TiledLayoutResult layout=PhotoLayoutHelper.processThumbs(imageAttachments);
 			MediaGridStatusDisplayItem mediaGrid=new MediaGridStatusDisplayItem(parentID, fragment, layout, imageAttachments, statusForContent);
 			if((flags & FLAG_MEDIA_FORCE_HIDDEN)!=0)

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposePollViewController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposePollViewController.java
@@ -74,10 +74,17 @@ public class ComposePollViewController{
 		pollWrap=view.findViewById(R.id.poll_wrap);
 
 		Instance instance=fragment.instance;
-		if(instance.configuration!=null && instance.configuration.polls!=null && instance.configuration.polls.maxOptions>0)
-			maxPollOptions=instance.configuration.polls.maxOptions;
-		if(instance.configuration!=null && instance.configuration.polls!=null && instance.configuration.polls.maxCharactersPerOption>0)
-			maxPollOptionLength=instance.configuration.polls.maxCharactersPerOption;
+		if (!instance.isAkkoma()) {
+			if(instance.configuration!=null && instance.configuration.polls!=null && instance.configuration.polls.maxOptions>0)
+				maxPollOptions=instance.configuration.polls.maxOptions;
+			if(instance.configuration!=null && instance.configuration.polls!=null && instance.configuration.polls.maxCharactersPerOption>0)
+				maxPollOptionLength=instance.configuration.polls.maxCharactersPerOption;
+		} else {
+			if (instance.pollLimits!=null && instance.pollLimits.maxOptions>0)
+				maxPollOptions=instance.pollLimits.maxOptions;
+			if(instance.pollLimits!=null && instance.pollLimits.maxOptionChars>0)
+				maxPollOptionLength=instance.pollLimits.maxOptionChars;
+		}
 
 		pollOptionsView=pollWrap.findViewById(R.id.poll_options);
 		addPollOptionBtn=pollWrap.findViewById(R.id.add_poll_option);


### PR DESCRIPTION
I noticed that some of my previous PRs related to Akkoma hadn't survived the move to the m3 redesign, so I decided to re-implement what was missing

While I was at it I also made the filter settings page hidden while using an Akkoma account because it would just give an error, and this app doesn't even support Akkoma's filter system anyways 