### PR TITLE
fix: copy link invisible on EMUI

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
@@ -171,7 +171,7 @@ public class HeaderStatusDisplayItem extends StatusDisplayItem{
 
 			optionsMenu=new PopupMenu(activity, more);
 			optionsMenu.inflate(R.menu.post);
-			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P)
+			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI())
 				optionsMenu.getMenu().setGroupDividerEnabled(true);
 			optionsMenu.setOnMenuItemClickListener(menuItem->{
 				Account account=item.user;


### PR DESCRIPTION
Same issue as in https://github.com/sk22/megalodon/pull/453, with the `Copy link to post` option being invisible on EMUI. Disabling should fix it.