### PR TITLE
fix(remote): send remoteAccount

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -14,6 +14,7 @@ import org.joinmastodon.android.model.viewmodel.AccountViewModel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.Callback;
@@ -136,6 +137,10 @@ public abstract class PaginatedAccountListFragment<T> extends BaseAccountListFra
 						List<AccountViewModel> items = result.stream()
 								.filter(a -> d.size() > 1000 || d.stream()
 										.noneMatch(i -> i.account.url.equals(a.url)))
+								.peek(account ->{
+									if (account.getDomainFromURL().equals(getRemoteDomain()))
+										account.acct=account.getFullyQualifiedName();
+								})
 								.map(a->new AccountViewModel(a, accountID))
 								.collect(Collectors.toList());
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -24,6 +25,7 @@ import android.widget.Toast;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.MastodonAPIController;
 import org.joinmastodon.android.api.requests.instance.GetInstanceExtendedDescription;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.viewmodel.AccountViewModel;
 import org.joinmastodon.android.model.viewmodel.ListItem;
@@ -126,6 +128,8 @@ public class SettingsServerAboutFragment extends LoaderFragment{
 			hlp.leftMargin=hlp.rightMargin=V.dp(16);
 			scrollingLayout.addView(heading, hlp);
 
+			// if a remote instance is shown, the account is remote and need to be loaded accordingly when shown
+			instance.contactAccount.isRemote=!AccountSessionManager.get(accountID).domain.equals(instance.normalizedUri);
 			AccountViewModel model=new AccountViewModel(instance.contactAccount, accountID);
 			AccountViewHolder holder=new AccountViewHolder(this, scrollingLayout, null);
 			holder.setStyle(AccountViewHolder.AccessoryType.NONE, false);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
@@ -190,7 +190,10 @@ public class AccountViewHolder extends BindableViewHolder<AccountViewModel> impl
 		}
 		Bundle args=new Bundle();
 		args.putString("account", accountID);
-		args.putParcelable("profileAccount", Parcels.wrap(item.account));
+		if (item.account.isRemote)
+			args.putParcelable("remoteAccount", Parcels.wrap(item.account));
+		else
+			args.putParcelable("profileAccount", Parcels.wrap(item.account));
 		Nav.go(fragment.getActivity(), ProfileFragment.class, args);
 	}
 


### PR DESCRIPTION
When opening a remote profile via the Following/Followers list, the profile shows correctly, but the status fails to load due to the ID being incorrect. This is a regression in M3 merge and can be fixed by sending the account as a remoteAccount.
 
| Before                                                                                                   	| After                                                                                                               	|
|----------------------------------------------------------------------------------------------------------	|---------------------------------------------------------------------------------------------------------------------	|
| ![Empty Profile](https://github.com/sk22/megalodon/assets/63370021/06904a59-5ad5-4ce9-8af8-87f9c4224879) 	| ![Correctly loaded profile](https://github.com/sk22/megalodon/assets/63370021/3a778154-a9cf-4866-bddc-b6f9dcf037b1) 	|
