### PR TITLE
build: add F-Droid flavor

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -34,6 +34,7 @@ android {
 		}
 		githubRelease { initWith release }
 		playRelease { initWith release }
+		fdroidRelease { initWith release }
 	}
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_17

--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -122,6 +122,12 @@ public class PushSubscriptionManager{
 
 
 	public void registerAccountForPush(PushSubscription subscription){
+		// this function is used for registering push notifications using FCM
+		// to avoid NonFreeNet in F-Droid, this registration is disabled in it
+		// see https://github.com/LucasGGamerM/moshidon/issues/206 for more context
+		if(BuildConfig.BUILD_TYPE.equals("fdroidRelease"))
+			return;
+
 		if(TextUtils.isEmpty(deviceToken))
 			throw new IllegalStateException("No device push token available");
 		String endpoint = "https://app.joinmastodon.org/relay-to/fcm/"+deviceToken+"/"+accountID;


### PR DESCRIPTION
Follow-up to https://github.com/sk22/megalodon/pull/749, adding a new build flavor for f-droid, which disables notification registration using FCM. This would allow Megalodon to be distributed over F-Droid without the `NonFreeNet` anti-feature.
See https://github.com/LucasGGamerM/moshidon/issues/206 for more context.