### PR TITLE
fix: display 'Lists with' placeholder

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
@@ -213,6 +213,7 @@ public class AccountViewHolder extends BindableViewHolder<AccountViewModel> impl
 		Account account=item.account;
 
 		menu.findItem(R.id.share).setTitle(fragment.getString(R.string.share_user, account.getDisplayUsername()));
+		menu.findItem(R.id.manage_user_lists).setTitle(fragment.getString(R.string.sk_lists_with_user, account.getShortUsername()));
 		menu.findItem(R.id.mute).setTitle(fragment.getString(relationship.muting ? R.string.unmute_user : R.string.mute_user, account.getDisplayUsername()));
 		menu.findItem(R.id.block).setTitle(fragment.getString(relationship.blocking ? R.string.unblock_user : R.string.block_user, account.getDisplayUsername()));
 		menu.findItem(R.id.report).setTitle(fragment.getString(R.string.report_user, account.getDisplayUsername()));


### PR DESCRIPTION
Fixes a missing string placeholder when long pressing a username in the detailed post info screen.
| Before                                                                                                                           	| After                                                                                                                         	|
|----------------------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------	|
| ![Display lists with Placeholder](https://github.com/LucasGGamerM/moshidon/assets/63370021/c83ff603-4f81-426b-afe0-370c7c5fa5d1) 	| ![Display lists with username](https://github.com/LucasGGamerM/moshidon/assets/63370021/da9a0afa-17b6-445a-9547-27972ebf68ef) 	|