### PR TITLE
fix: move tabbar padding to tabbar items

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -126,19 +126,19 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		tabBar.setListeners(this::onTabSelected, this::onTabLongClick);
 		tabBarWrap=content.findViewById(R.id.tabbar_wrap);
 
-		View[] tabs={
-				tabBar.findViewById(R.id.tab_home),
-				tabBar.findViewById(R.id.tab_search),
-				tabBar.findViewById(R.id.tab_notifications),
-				tabBar.findViewById(R.id.tab_profile)
-		};
-
 		// this one's for the pill haters (https://m3.material.io/components/navigation-bar/overview)
 		if(GlobalUserPreferences.disableM3PillActiveIndicator){
 			tabBar.findViewById(R.id.tab_home_pill).setBackground(null);
 			tabBar.findViewById(R.id.tab_search_pill).setBackground(null);
 			tabBar.findViewById(R.id.tab_notifications_pill).setBackground(null);
 			tabBar.findViewById(R.id.tab_profile_pill).setBackgroundResource(R.drawable.bg_tab_profile);
+
+			View[] tabs={
+					tabBar.findViewById(R.id.tab_home),
+					tabBar.findViewById(R.id.tab_search),
+					tabBar.findViewById(R.id.tab_notifications),
+					tabBar.findViewById(R.id.tab_profile)
+			};
 
 			for(View tab : tabs){
 				tab.setBackgroundResource(R.drawable.bg_tabbar_tab_ripple);
@@ -152,10 +152,6 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			tabBar.findViewById(R.id.tab_search_label).setVisibility(View.GONE);
 			tabBar.findViewById(R.id.tab_notifications_label).setVisibility(View.GONE);
 			tabBar.findViewById(R.id.tab_profile_label).setVisibility(View.GONE);
-			for(View tab : tabs){
-				tab.setPadding(tab.getPaddingLeft(), tab.getPaddingTop(), tab.getPaddingRight(), tabBar.getPaddingBottom());
-			}
-			tabBar.setPadding(tabBar.getPaddingLeft(), tabBar.getPaddingTop(), tabBar.getPaddingRight(), 4);
 		}
 
 		tabBarAvatar=tabBar.findViewById(R.id.tab_profile_ava);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -126,19 +126,19 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		tabBar.setListeners(this::onTabSelected, this::onTabLongClick);
 		tabBarWrap=content.findViewById(R.id.tabbar_wrap);
 
+		View[] tabs={
+				tabBar.findViewById(R.id.tab_home),
+				tabBar.findViewById(R.id.tab_search),
+				tabBar.findViewById(R.id.tab_notifications),
+				tabBar.findViewById(R.id.tab_profile)
+		};
+
 		// this one's for the pill haters (https://m3.material.io/components/navigation-bar/overview)
 		if(GlobalUserPreferences.disableM3PillActiveIndicator){
 			tabBar.findViewById(R.id.tab_home_pill).setBackground(null);
 			tabBar.findViewById(R.id.tab_search_pill).setBackground(null);
 			tabBar.findViewById(R.id.tab_notifications_pill).setBackground(null);
 			tabBar.findViewById(R.id.tab_profile_pill).setBackgroundResource(R.drawable.bg_tab_profile);
-
-			View[] tabs={
-					tabBar.findViewById(R.id.tab_home),
-					tabBar.findViewById(R.id.tab_search),
-					tabBar.findViewById(R.id.tab_notifications),
-					tabBar.findViewById(R.id.tab_profile)
-			};
 
 			for(View tab : tabs){
 				tab.setBackgroundResource(R.drawable.bg_tabbar_tab_ripple);
@@ -152,6 +152,10 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			tabBar.findViewById(R.id.tab_search_label).setVisibility(View.GONE);
 			tabBar.findViewById(R.id.tab_notifications_label).setVisibility(View.GONE);
 			tabBar.findViewById(R.id.tab_profile_label).setVisibility(View.GONE);
+			for(View tab : tabs){
+				tab.setPadding(tab.getPaddingLeft(), tab.getPaddingTop(), tab.getPaddingRight(), tabBar.getPaddingBottom());
+			}
+			tabBar.setPadding(tabBar.getPaddingLeft(), tabBar.getPaddingTop(), tabBar.getPaddingRight(), 4);
 		}
 
 		tabBarAvatar=tabBar.findViewById(R.id.tab_profile_ava);

--- a/mastodon/src/main/res/layout/tab_bar.xml
+++ b/mastodon/src/main/res/layout/tab_bar.xml
@@ -13,7 +13,6 @@
 		android:id="@+id/tabbar"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:paddingTop="12dp"
 		android:paddingHorizontal="8dp">
 
 		<LinearLayout
@@ -22,6 +21,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingTop="12dp"
 			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
@@ -61,6 +61,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingTop="12dp"
 			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
@@ -100,6 +101,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingTop="12dp"
 			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
@@ -157,6 +159,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingTop="12dp"
 			android:paddingBottom="16dp"
 			android:orientation="vertical">
 

--- a/mastodon/src/main/res/layout/tab_bar.xml
+++ b/mastodon/src/main/res/layout/tab_bar.xml
@@ -14,7 +14,6 @@
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:paddingTop="12dp"
-		android:paddingBottom="16dp"
 		android:paddingHorizontal="8dp">
 
 		<LinearLayout
@@ -23,6 +22,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
 			<FrameLayout
@@ -61,6 +61,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
 			<FrameLayout
@@ -99,6 +100,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
 			<RelativeLayout
@@ -155,6 +157,7 @@
 			android:layout_height="match_parent"
 			android:layout_weight="1"
 			android:layout_marginEnd="8dp"
+			android:paddingBottom="16dp"
 			android:orientation="vertical">
 
 			<FrameLayout


### PR DESCRIPTION
Moves the tabbar padding from the tabbar to the individual tabbar items.
This fixes the issue where the spaces below the items is not clickable (does not select a tab), which is especially noticeable when disabling the labels.