### PR TITLE
Fix unreliable Preferences from Account Source

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSession.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSession.java
@@ -148,6 +148,7 @@ public class AccountSession{
 						Log.w(TAG, "Failed to load preferences for account "+getID()+": "+error);
 						if (preferences==null)
 							preferences=new Preferences();
+						preferencesFromAccountSource(self);
 					}
 				})
 				.exec(getID());

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSession.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSession.java
@@ -146,6 +146,8 @@ public class AccountSession{
 					@Override
 					public void onError(ErrorResponse error){
 						Log.w(TAG, "Failed to load preferences for account "+getID()+": "+error);
+						if (preferences==null)
+							preferences=new Preferences();
 					}
 				})
 				.exec(getID());


### PR DESCRIPTION
The `AccountSession.preferencesFromAccountSource` method would only work if the `preferences` field wasn't null, but that would only be the case either if the GetPreferences endpoint succeeded or the user had changed the default posting language

This function is really only useful for accounts that don't have the GetPreferences endpoint, so it should also be set properly when the endpoint gives an error (without the user manually having to change language)