### PR TITLE
fix: allows for editing timeline badges again. fixes sk22#800

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -344,7 +344,7 @@ public class EditTimelinesFragment extends MastodonRecyclerFragment<TimelineDefi
                         mainHashtag = name;
                         name = null;
                     }
-                    if (TextUtils.isEmpty(mainHashtag)) {
+                    if (TextUtils.isEmpty(mainHashtag) && (item != null && item.getType() == TimelineDefinition.TimelineType.HASHTAG)) {
                         Toast.makeText(ctx, R.string.sk_add_timeline_tag_error_empty, Toast.LENGTH_SHORT).show();
                         onSave.accept(null);
                         return;


### PR DESCRIPTION
This fixes the bug where you cannot edit timeline badges