### PR TITLE
fix: use random account id in notification endpoint

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -130,12 +130,11 @@ public class PushSubscriptionManager{
 			return;
 		}
 
-		String endpoint = "https://app.joinmastodon.org/relay-to/fcm/"+deviceToken+"/"+accountID;
+		String endpoint = "https://app.joinmastodon.org/relay-to/fcm/"+deviceToken+"/";
 		registerAccountForPush(subscription, endpoint);
 	}
 
 	public void registerAccountForPush(PushSubscription subscription, String endpoint){
-
 		MastodonAPIController.runInBackground(()->{
 			Log.d(TAG, "registerAccountForPush: started for "+accountID);
 			String encodedPublicKey, encodedAuthKey, pushAccountID;
@@ -164,7 +163,13 @@ public class PushSubscriptionManager{
 				Log.e(TAG, "registerAccountForPush: error generating encryption key", e);
 				return;
 			}
-			new RegisterForPushNotifications(endpoint,
+
+			//work-around for adding the randomAccountId
+			String newEndpoint = endpoint;
+			if (endpoint.startsWith("https://app.joinmastodon.org/relay-to/fcm/"))
+				newEndpoint += pushAccountID;
+
+			new RegisterForPushNotifications(newEndpoint,
 					encodedPublicKey,
 					encodedAuthKey,
 					subscription==null ? PushSubscription.Alerts.ofAll() : subscription.alerts,


### PR DESCRIPTION
Closes https://github.com/sk22/megalodon/issues/803 and https://github.com/LucasGGamerM/moshidon/issues/254. This was due to registering with the actual account ID while saving a random one. After receiving a notification, the ID could not be found compared to the saved random one, so no notification was displayed.

The problem only occurred when a user tried to re-register with FCM, either by switching from Unified Push or by changing the notification settings, so only some users were affected.