### PR TITLE
fix: fixes crashes when currentQuery is null and suicide prevention dialog is enabled

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchQueryFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchQueryFragment.java
@@ -388,7 +388,7 @@ public class SearchQueryFragment extends MastodonRecyclerFragment<SearchResultVi
 	}
 
 	private void wrapSuicideDialog(Runnable r){
-		if(!GlobalUserPreferences.showSuicideHelp){
+		if(!GlobalUserPreferences.showSuicideHelp || currentQuery==null){
 			r.run();
 			return;
 		}


### PR DESCRIPTION
This happens when you tap on a recent search and the current query is null. This is caused by the suicide help prevention dialog not checking if the currentQuery is null before trimming it. This addresses that issue