### PR TITLE
Fix notifications replies visibility/language not being consistent with replied status

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -321,7 +321,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 
 		CreateStatus.Request req=new CreateStatus.Request();
 		req.status = initialText + input.toString();
-		req.language = preferences.postingDefaultLanguage;
+		req.language = notification.status.language;
 		req.visibility = notification.status.visibility;
 		req.inReplyToId = notification.status.id;
 

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -322,7 +322,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		CreateStatus.Request req=new CreateStatus.Request();
 		req.status = initialText + input.toString();
 		req.language = preferences.postingDefaultLanguage;
-		req.visibility = preferences.postingDefaultVisibility;
+		req.visibility = notification.status.visibility;
 		req.inReplyToId = notification.status.id;
 
 		if (notification.status.hasSpoiler() &&


### PR DESCRIPTION
This fixes a bug where you would reply to a mentioned-only post from the notification and the reply would be set to public. 