### PR TITLE
fix(hashtag-fragment): fix crash when opening some hashtags

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -85,7 +85,7 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment{
 
 	@Override
 	protected TimelineDefinition makeTimelineDefinition() {
-		return TimelineDefinition.ofHashtag(hashtag);
+		return TimelineDefinition.ofHashtag(hashtagName);
 	}
 
 	@Override


### PR DESCRIPTION
This is caused by calling TimelineDefinition.of(hashtag), where the hashtag was previously a String, but its now a Hashtag. But by consequece, hashtag can be null. This addresses that by using hashtagName instead of hashtag