### PR TITLE
fix(translations): fix crash when status language is null

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.model.Translation;
@@ -207,7 +208,7 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 				translationProgress.setVisibility(View.GONE);
 				Translation existingTrans=item.status.getContentStatus().translation;
 				String lang=existingTrans!=null ? existingTrans.detectedSourceLanguage : null;
-				String displayLang=Locale.forLanguageTag(lang!=null ? lang : item.status.getContentStatus().language).getDisplayLanguage();
+				String displayLang=Locale.forLanguageTag(lang!=null ? lang : (item.status.getContentStatus().language != null ? item.status.getContentStatus().language : AccountSessionManager.get(item.parentFragment.getAccountID()).preferences.postingDefaultLanguage)).getDisplayLanguage();
 				translationButton.setText(item.parentFragment.getString(R.string.translate_post, !displayLang.isBlank() ? displayLang : lang));
 				translationButton.setEnabled(true);
 				translationButton.setAlpha(1);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
@@ -207,8 +207,10 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 				translationFooter.setVisibility(translateEnabled ? View.VISIBLE : View.GONE);
 				translationProgress.setVisibility(View.GONE);
 				Translation existingTrans=item.status.getContentStatus().translation;
-				String lang=existingTrans!=null ? existingTrans.detectedSourceLanguage : null;
-				String displayLang=Locale.forLanguageTag(lang!=null ? lang : (item.status.getContentStatus().language != null ? item.status.getContentStatus().language : AccountSessionManager.get(item.parentFragment.getAccountID()).preferences.postingDefaultLanguage)).getDisplayLanguage();
+				String existingTransLang=existingTrans!=null ? existingTrans.detectedSourceLanguage : null;
+				String lang=existingTransLang!=null ? existingTransLang : item.status.getContentStatus().language;
+				String displayLang=Locale.forLanguageTag(lang != null ? lang
+						: AccountSessionManager.get(item.parentFragment.getAccountID()).preferences.postingDefaultLanguage).getDisplayLanguage();
 				translationButton.setText(item.parentFragment.getString(R.string.translate_post, !displayLang.isBlank() ? displayLang : lang));
 				translationButton.setEnabled(true);
 				translationButton.setAlpha(1);


### PR DESCRIPTION
This fixes a crash that happens from time to time on the timeline where the translate system would try to know what language a status has, but the status has no language 