### PR TITLE
fix: hiding discovery on Akkoma + hiding privacy settings

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -32,7 +32,6 @@ import org.joinmastodon.android.events.NotificationsMarkerUpdatedEvent;
 import org.joinmastodon.android.events.StatusDisplaySettingsChangedEvent;
 import org.joinmastodon.android.fragments.discover.DiscoverFragment;
 import org.joinmastodon.android.model.Account;
-import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.Notification;
 import org.joinmastodon.android.model.PaginatedResponse;
 import org.joinmastodon.android.ui.AccountSwitcherSheet;
@@ -71,14 +70,12 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	private TextView notificationsBadge;
 
 	private String accountID;
-	private boolean isAkkoma;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
 		accountID=getArguments().getString("account");
 		setTitle(R.string.sk_app_name);
-		isAkkoma = getInstance().map(Instance::isAkkoma).orElse(false);
 
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N)
 			setRetainInstance(true);
@@ -89,7 +86,6 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			homeTabFragment=new HomeTabFragment();
 			homeTabFragment.setArguments(args);
 			args=new Bundle(args);
-			args.putBoolean("disableDiscover", isAkkoma);
 			args.putBoolean("noAutoLoad", true);
 			discoverFragment=new DiscoverFragment();
 			discoverFragment.setArguments(args);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -13,8 +13,10 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
+import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.SearchResult;
 import org.joinmastodon.android.ui.OutlineProviders;
 import org.joinmastodon.android.ui.SimpleViewHolder;
@@ -155,7 +157,7 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 			}
 		});
 
-		disableDiscover=getArguments().getBoolean("disableDiscover");
+		disableDiscover=AccountSessionManager.get(accountID).getInstance().map(Instance::isAkkoma).orElse(false);
 		searchView=view.findViewById(R.id.search_fragment);
 		if(searchFragment==null){
 			searchFragment=new SearchFragment();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsMainFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsMainFragment.java
@@ -63,8 +63,8 @@ public class SettingsMainFragment extends BaseSettingsFragment<Void>{
 
 		Instance instance = AccountSessionManager.getInstance().getInstanceInfo(account.domain);
 		if (!instance.isAkkoma()){
-			data.add(2, new ListItem<>(R.string.settings_filters, 0, R.drawable.ic_fluent_filter_24_regular, this::onFiltersClick));
 			data.add(2, new ListItem<>(R.string.settings_privacy, 0, R.drawable.ic_fluent_shield_24_regular, this::onPrivacyClick));
+			data.add(3, new ListItem<>(R.string.settings_filters, 0, R.drawable.ic_fluent_filter_24_regular, this::onFiltersClick));
 		}
 
 		if(BuildConfig.DEBUG || BuildConfig.BUILD_TYPE.equals("appcenterPrivateBeta")){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsMainFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsMainFragment.java
@@ -55,7 +55,6 @@ public class SettingsMainFragment extends BaseSettingsFragment<Void>{
 		onDataLoaded(List.of(
 				new ListItem<>(R.string.settings_behavior, 0, R.drawable.ic_fluent_settings_24_regular, this::onBehaviorClick),
 				new ListItem<>(R.string.settings_display, 0, R.drawable.ic_fluent_color_24_regular, this::onDisplayClick),
-				new ListItem<>(R.string.settings_privacy, 0, R.drawable.ic_fluent_shield_24_regular, this::onPrivacyClick),
 				new ListItem<>(R.string.settings_notifications, 0, R.drawable.ic_fluent_alert_24_regular, this::onNotificationsClick),
 				new ListItem<>(R.string.sk_settings_instance, 0, R.drawable.ic_fluent_server_24_regular, this::onInstanceClick),
 				new ListItem<>(getString(R.string.about_app, getString(R.string.sk_app_name)), null, R.drawable.ic_fluent_info_24_regular, this::onAboutClick, null, 0, true),
@@ -63,8 +62,10 @@ public class SettingsMainFragment extends BaseSettingsFragment<Void>{
 		));
 
 		Instance instance = AccountSessionManager.getInstance().getInstanceInfo(account.domain);
-		if (!instance.isAkkoma())
-			data.add(3, new ListItem<>(R.string.settings_filters, 0, R.drawable.ic_fluent_filter_24_regular, this::onFiltersClick));
+		if (!instance.isAkkoma()){
+			data.add(2, new ListItem<>(R.string.settings_filters, 0, R.drawable.ic_fluent_filter_24_regular, this::onFiltersClick));
+			data.add(2, new ListItem<>(R.string.settings_privacy, 0, R.drawable.ic_fluent_shield_24_regular, this::onPrivacyClick));
+		}
 
 		if(BuildConfig.DEBUG || BuildConfig.BUILD_TYPE.equals("appcenterPrivateBeta")){
 			data.add(0, new ListItem<>("Debug settings", null, R.drawable.ic_fluent_wrench_screwdriver_24_regular, ()->Nav.go(getActivity(), SettingsDebugFragment.class, makeFragmentArgs()), null, 0, true));


### PR DESCRIPTION
There was a bug in my previous PR for hiding the discovery page on Akkoma where it would still show if the instance info hadn't been fetched before it tried to find out if it should hide discovery. It seems like it always will have this info when running onCreateView for the discovery fragment instead of onCreate for the home fragment

New settings were introduced recently for some new Mastodon privacy options, but Akkoma doesn't have these. It does have one that's similar that's also called discoverable, but it's located in a different place in the API, and it's also not fully the same. From my understanding, Mastodon's setting is about Mastodon search while Akkoma's is about external search engines, so the setting would probably need a different implementation in Megalodon for it to make sense to show it, and so I think it should be hidden at least for now