### PR TITLE
Fix: registering multi account for UnifiedPush

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -1,5 +1,7 @@
 package org.joinmastodon.android.api.session;
 
+import static org.unifiedpush.android.connector.UnifiedPush.getDistributor;
+
 import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.ComponentName;
@@ -34,6 +36,7 @@ import org.joinmastodon.android.model.EmojiCategory;
 import org.joinmastodon.android.model.LegacyFilter;
 import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.Token;
+import org.unifiedpush.android.connector.UnifiedPush;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -101,6 +104,7 @@ public class AccountSessionManager{
 	}
 
 	public void addAccount(Instance instance, Token token, Account self, Application app, AccountActivationInfo activationInfo){
+		Context context = MastodonApp.context;
 		instances.put(instance.uri, instance);
 		AccountSession session=new AccountSession(token, self, app, instance.uri, activationInfo==null, activationInfo);
 		sessions.put(session.getID(), session);
@@ -113,7 +117,14 @@ public class AccountSessionManager{
 		MastodonAPIController.runInBackground(()->writeInstanceInfoFile(wrapper, instance.uri));
 
 		updateMoreInstanceInfo(instance, instance.uri);
-		if(PushSubscriptionManager.arePushNotificationsAvailable()){
+		if (!UnifiedPush.getDistributor(context).isEmpty()) {
+			UnifiedPush.registerApp(
+					context,
+					session.getID(),
+					new ArrayList<>(),
+					context.getPackageName()
+			);
+		} else if(PushSubscriptionManager.arePushNotificationsAvailable()){
 			session.getPushSubscriptionManager().registerAccountForPush(null);
 		}
 		maybeUpdateShortcuts();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
@@ -334,13 +334,15 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 			return;
 		}
 
-		UnifiedPush.unregisterApp(
-				getContext(),
-				accountID
-		);
+		for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()) {
+			UnifiedPush.unregisterApp(
+					getContext(),
+					accountSession.getID()
+			);
 
-		//re-register to fcm
-		AccountSessionManager.getInstance().getAccount(accountID).getPushSubscriptionManager().registerAccountForPush(getPushSubscription());
+			//re-register to fcm
+			accountSession.getPushSubscriptionManager().registerAccountForPush(getPushSubscription());
+		}
 		unifiedPushItem.toggle();
 		rebindItem(unifiedPushItem);
 	}
@@ -350,12 +352,14 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 				(dialog, which)->{
 					String userDistrib = distributors.get(which);
 					UnifiedPush.saveDistributor(getContext(), userDistrib);
-					UnifiedPush.registerApp(
-							getContext(),
-							accountID,
-							new ArrayList<>(),
-							getContext().getPackageName()
-					);
+					for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()){
+						UnifiedPush.registerApp(
+								getContext(),
+								accountSession.getID(),
+								new ArrayList<>(),
+								getContext().getPackageName()
+						);
+					}
 					unifiedPushItem.toggle();
 					rebindItem(unifiedPushItem);
 				}).setOnCancelListener(d->rebindItem(unifiedPushItem)).show();


### PR DESCRIPTION
Currently, when toggling on/off UnifiedPush, only the current account is getting (un)registered. And new account don't get registered. This PR fixes this.