### PR TITLE
Fix NullPointerException when receiving push when killed

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSession.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSession.java
@@ -260,11 +260,13 @@ public class AccountSession{
 	}
 
 	private boolean isFilteredType(Status s){
+		AccountLocalPreferences localPreferences = getLocalPreferences();
 		return (!localPreferences.showReplies && s.inReplyToId != null)
 				|| (!localPreferences.showBoosts && s.reblog != null);
 	}
 
 	public <T> void filterStatusContainingObjects(List<T> objects, Function<T, Status> extractor, FilterContext context, Account profile){
+		AccountLocalPreferences localPreferences = getLocalPreferences();
 		if(!localPreferences.serverSideFiltersSupported) for(T obj:objects){
 			Status s=extractor.apply(obj);
 			if(s!=null && s.filtered!=null){
@@ -307,7 +309,7 @@ public class AccountSession{
 		if(isFilteredType(s) && (context == FilterContext.HOME || context == FilterContext.PUBLIC))
 			return true;
 		// Even with server-side filters, clients are expected to remove statuses that match a filter that hides them
-		if(localPreferences.serverSideFiltersSupported){
+		if(getLocalPreferences().serverSideFiltersSupported){
 			for(FilterResult filter : s.filtered){
 				if(filter.filter.isActive() && filter.filter.filterAction==FilterAction.HIDE)
 					return true;


### PR DESCRIPTION
When receiving a push notification while the app is killed, `filterStatusContainingObjects` is called and it uses `localPreferences` before it is initialized and causes a NullPointerException. This PR changes `AccountSession.class` so `getLocalPreferences` is always called to be sure `localPreferences` is initialized.

---

logcat:

```
2023-10-30 19:38:56.860 16727-16727 AndroidRuntime          pid-16727                            E  FATAL EXCEPTION: main
                                                                                                    Process: org.joinmastodon.android.sk.debug, PID: 16727
                                                                                                    java.lang.NullPointerException: Attempt to read from field 'boolean org.joinmastodon.android.api.session.AccountLocalPreferences.serverSideFiltersSupported' on a null object reference in method 'void org.joinmastodon.android.api.session.AccountSession.filterStatusContainingObjects(java.util.List, java.util.function.Function, org.joinmastodon.android.model.FilterContext, org.joinmastodon.android.model.Account)'
                                                                                                    	at org.joinmastodon.android.api.session.AccountSession.filterStatusContainingObjects(AccountSession.java:268)
                                                                                                    	at org.joinmastodon.android.api.session.AccountSession.filterStatusContainingObjects(AccountSession.java:254)
                                                                                                    	at org.joinmastodon.android.api.CacheController$2.onSuccess(CacheController.java:192)
                                                                                                    	at org.joinmastodon.android.api.CacheController$2.onSuccess(CacheController.java:188)
                                                                                                    	at me.grishka.appkit.api.APIRequest$1.run(APIRequest.java:29)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:958)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205)
                                                                                                    	at android.os.Looper.loop(Looper.java:294)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8199)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
