### PR TITLE
feat: translate media attachments and poll options

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -890,6 +890,11 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 			notifyItemChanged(itemID, TextStatusDisplayItem.class);
 		}
 
+		SpoilerStatusDisplayItem.Holder spoiler=findHolderOfType(itemID, SpoilerStatusDisplayItem.Holder.class);
+		if(spoiler!=null){
+			spoiler.rebind();
+		}
+
 		MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
 		if (media!=null) {
 			media.rebind();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -858,6 +858,10 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 										return;
 									status.translation=result;
 									status.translationState=Status.TranslationState.SHOWN;
+									MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
+									if (media!=null) {
+										media.rebind();
+									}
 									TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
 									if(text!=null){
 										text.updateTranslation(true);
@@ -896,7 +900,14 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		}else{
 			notifyItemChanged(itemID, TextStatusDisplayItem.class);
 		}
+
+		MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
+		if (media!=null) {
+			media.rebind();
+		}
 	}
+
+	private void updateTranslation() {}
 
 	public void rebuildAllDisplayItems(){
 		displayItems.clear();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -493,7 +493,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 			spoilerFooterIndex=spoilerItem.contentItems.indexOf(pollItems.get(pollItems.size()-1));
 		}
 		pollItems.clear();
-		StatusDisplayItem.buildPollItems(itemID, this, poll, pollItems);
+		StatusDisplayItem.buildPollItems(itemID, this, poll, status, pollItems);
 		if(spoilerItem!=null){
 			spoilerItem.contentItems.subList(spoilerFirstOptionIndex, spoilerFooterIndex+1).clear();
 			spoilerItem.contentItems.addAll(spoilerFirstOptionIndex, pollItems);
@@ -858,17 +858,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 										return;
 									status.translation=result;
 									status.translationState=Status.TranslationState.SHOWN;
-									MediaGridStatusDisplayItem.Holder media=findHolderOfType(itemID, MediaGridStatusDisplayItem.Holder.class);
-									if (media!=null) {
-										media.rebind();
-									}
-									TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
-									if(text!=null){
-										text.updateTranslation(true);
-										imgLoader.bindViewHolder((ImageLoaderRecyclerAdapter) list.getAdapter(), text, text.getAbsoluteAdapterPosition());
-									}else{
-										notifyItemChanged(itemID, TextStatusDisplayItem.class);
-									}
+									updateTranslation(itemID);
 								}
 
 								@Override
@@ -876,12 +866,7 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 									if(getActivity()==null)
 										return;
 									status.translationState=Status.TranslationState.HIDDEN;
-									TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
-									if(text!=null){
-										text.updateTranslation(true);
-									}else{
-										notifyItemChanged(itemID, TextStatusDisplayItem.class);
-									}
+									updateTranslation(itemID);
 									new M3AlertDialogBuilder(getActivity())
 											.setTitle(R.string.error)
 											.setMessage(R.string.translation_failed)
@@ -893,6 +878,10 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 				}
 			}
 		}
+		updateTranslation(itemID);
+	}
+
+	private void updateTranslation(String itemID) {
 		TextStatusDisplayItem.Holder text=findHolderOfType(itemID, TextStatusDisplayItem.Holder.class);
 		if(text!=null){
 			text.updateTranslation(true);
@@ -905,9 +894,13 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		if (media!=null) {
 			media.rebind();
 		}
-	}
 
-	private void updateTranslation() {}
+		for(int i=0;i<list.getChildCount();i++){
+			if(list.getChildViewHolder(list.getChildAt(i)) instanceof PollOptionStatusDisplayItem.Holder item){
+				item.rebind();
+			}
+		}
+	}
 
 	public void rebuildAllDisplayItems(){
 		displayItems.clear();

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -10,6 +10,7 @@ public class Translation extends BaseModel{
 	public String detectedSourceLanguage;
 	@RequiredField
 	public String provider;
+	public String spoilerText;
 	public MediaAttachment[] mediaAttachments;
 	public PollTranslation poll;
 

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -1,11 +1,14 @@
 package org.joinmastodon.android.model;
 
-import org.joinmastodon.android.api.AllFieldsAreRequired;
 
-@AllFieldsAreRequired
+import org.joinmastodon.android.api.RequiredField;
+
 public class Translation extends BaseModel{
+	@RequiredField
 	public String content;
+	@RequiredField
 	public String detectedSourceLanguage;
+	@RequiredField
 	public String provider;
 	public MediaAttachment[] mediaAttachments;
 	public PollTranslation poll;

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -7,4 +7,10 @@ public class Translation extends BaseModel{
 	public String content;
 	public String detectedSourceLanguage;
 	public String provider;
+	public MediaAttachment[] mediaAttachments;
+
+	public static class MediaAttachment {
+		public String id;
+		public String description;
+	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Translation.java
@@ -8,9 +8,19 @@ public class Translation extends BaseModel{
 	public String detectedSourceLanguage;
 	public String provider;
 	public MediaAttachment[] mediaAttachments;
+	public PollTranslation poll;
 
 	public static class MediaAttachment {
 		public String id;
 		public String description;
+	}
+
+	public static class PollTranslation {
+		public String id;
+		public PollOption[] options;
+	}
+
+	public static class PollOption {
+		public String title;
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/MediaGridStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/MediaGridStatusDisplayItem.java
@@ -12,6 +12,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,6 +27,7 @@ import org.joinmastodon.android.R;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.Attachment;
 import org.joinmastodon.android.model.Status;
+import org.joinmastodon.android.model.Translation;
 import org.joinmastodon.android.ui.OutlineProviders;
 import org.joinmastodon.android.ui.PhotoLayoutHelper;
 import org.joinmastodon.android.ui.drawables.SpoilerStripesDrawable;
@@ -38,7 +40,12 @@ import org.joinmastodon.android.ui.views.MediaGridLayout;
 import org.joinmastodon.android.utils.TypedObjectPool;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import me.grishka.appkit.imageloader.ImageLoaderViewHolder;
 import me.grishka.appkit.imageloader.requests.ImageLoaderRequest;
@@ -52,6 +59,7 @@ public class MediaGridStatusDisplayItem extends StatusDisplayItem{
 	private PhotoLayoutHelper.TiledLayoutResult tiledLayout;
 	private final TypedObjectPool<GridItemType, MediaAttachmentViewController> viewPool;
 	private final List<Attachment> attachments;
+	private final Map<String, Pair<String, String>> translatedAttachments = new HashMap<>();
 	private final ArrayList<ImageLoaderRequest> requests=new ArrayList<>();
 	public final Status status;
 	public String sensitiveTitle;
@@ -189,6 +197,25 @@ public class MediaGridStatusDisplayItem extends StatusDisplayItem{
 					c.btnsWrap.setAlpha(1f);
 				}
 				controllers.add(c);
+
+				if (item.status.translation != null){
+					if(item.status.translationState==Status.TranslationState.SHOWN){
+						if(!item.translatedAttachments.containsKey(att.id)){
+							Optional<Translation.MediaAttachment> translatedAttachment=Arrays.stream(item.status.translation.mediaAttachments).filter(mediaAttachment->mediaAttachment.id.equals(att.id)).findFirst();
+							translatedAttachment.ifPresent(mediaAttachment->{
+								item.translatedAttachments.put(mediaAttachment.id, new Pair<>(att.description, mediaAttachment.description));
+								att.description=mediaAttachment.description;
+							});
+						}else{
+							//SAFETY: must be non-null, as we check if the map contains the attachment before
+							att.description=Objects.requireNonNull(item.translatedAttachments.get(att.id)).second;
+						}
+					}else{
+						if (item.translatedAttachments.containsKey(att.id)) {
+							att.description=Objects.requireNonNull(item.translatedAttachments.get(att.id)).first;
+						}
+					}
+				}
 				c.bind(att, item.status);
 				i++;
 			}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.Poll;
+import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.ui.OutlineProviders;
 import org.joinmastodon.android.ui.text.HtmlParser;
 import org.joinmastodon.android.ui.utils.CustomEmojiHelper;
@@ -23,6 +24,7 @@ import me.grishka.appkit.imageloader.requests.ImageLoaderRequest;
 
 public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 	private CharSequence text;
+	private CharSequence translatedText;
 	public final Poll.Option option;
 	private CustomEmojiHelper emojiHelper=new CustomEmojiHelper();
 	private boolean showResults;
@@ -30,12 +32,15 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 	private boolean isMostVoted;
 	private final int optionIndex;
 	public final Poll poll;
+	public final Status status;
 
-	public PollOptionStatusDisplayItem(String parentID, Poll poll, int optionIndex, BaseStatusListFragment parentFragment){
+
+	public PollOptionStatusDisplayItem(String parentID, Poll poll, int optionIndex, BaseStatusListFragment parentFragment, Status status){
 		super(parentID, parentFragment);
 		this.optionIndex=optionIndex;
 		option=poll.options.get(optionIndex);
 		this.poll=poll;
+		this.status=status;
 		text=HtmlParser.parseCustomEmoji(option.title, poll.emojis);
 		emojiHelper.setText(text);
 		showResults=poll.isExpired() || poll.voted;
@@ -84,7 +89,14 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 
 		@Override
 		public void onBind(PollOptionStatusDisplayItem item){
-			text.setText(item.text);
+			if (item.status.translation != null && item.status.translationState == Status.TranslationState.SHOWN) {
+				if(item.translatedText==null){
+					item.translatedText=item.status.translation.poll.options[item.optionIndex].title;
+				}
+				text.setText(item.translatedText);
+			} else {
+				text.setText(item.text);
+			}
 			percent.setVisibility(item.showResults ? View.VISIBLE : View.GONE);
 			itemView.setClickable(!item.showResults);
 			icon.setImageDrawable(itemView.getContext().getDrawable(item.poll.multiple ?

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/SpoilerStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/SpoilerStatusDisplayItem.java
@@ -27,6 +27,7 @@ public class SpoilerStatusDisplayItem extends StatusDisplayItem{
 	public final Status status;
 	public final ArrayList<StatusDisplayItem> contentItems=new ArrayList<>();
 	private final CharSequence parsedTitle;
+	private CharSequence translatedTitle;
 	private final CustomEmojiHelper emojiHelper;
 	private final Type type;
 	private final int attachmentCount;
@@ -90,7 +91,14 @@ public class SpoilerStatusDisplayItem extends StatusDisplayItem{
 
 		@Override
 		public void onBind(SpoilerStatusDisplayItem item){
-			title.setText(item.parsedTitle);
+			if(item.status.translationState==Status.TranslationState.SHOWN){
+				if(item.translatedTitle==null){
+					item.translatedTitle=item.status.translation.spoilerText;
+				}
+				title.setText(item.translatedTitle);
+			}else{
+				title.setText(item.parsedTitle);
+			}
 			action.setText(item.status.spoilerRevealed ? R.string.spoiler_hide : R.string.sk_spoiler_show);
 			itemView.setPadding(
 					itemView.getPaddingLeft(),

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -285,7 +285,7 @@ public abstract class StatusDisplayItem{
 			}
 		}
 		if(statusForContent.poll!=null){
-			buildPollItems(parentID, fragment, statusForContent.poll, contentItems);
+			buildPollItems(parentID, fragment, statusForContent.poll, status, contentItems);
 		}
 		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty()){
 			contentItems.add(new LinkCardStatusDisplayItem(parentID, fragment, statusForContent));
@@ -339,10 +339,10 @@ public abstract class StatusDisplayItem{
 		);
 	}
 
-	public static void buildPollItems(String parentID, BaseStatusListFragment fragment, Poll poll, List<StatusDisplayItem> items){
+	public static void buildPollItems(String parentID, BaseStatusListFragment fragment, Poll poll, Status status, List<StatusDisplayItem> items){
 		int i=0;
 		for(Poll.Option opt:poll.options){
-			items.add(new PollOptionStatusDisplayItem(parentID, poll, i, fragment));
+			items.add(new PollOptionStatusDisplayItem(parentID, poll, i, fragment, status));
 			i++;
 		}
 		items.add(new PollFooterStatusDisplayItem(parentID, fragment, poll));


### PR DESCRIPTION
Adds the ability to translate not only status text, but also media attachment descriptions (alt text) and poll options, a new feature introduced in [4.2.0](https://github.com/mastodon/mastodon/releases/tag/v4.2.0).

| Untranslated                                                                                                       	| Translated                                                                                                      	|
|--------------------------------------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------	|
| ![Untranslated poll](https://github.com/sk22/megalodon/assets/63370021/0140f438-2a78-4cc2-bbdc-921857d72147) 	| ![Translated poll](https://github.com/sk22/megalodon/assets/63370021/ea109b7b-1adb-4f75-a3c8-08f6ca95df7c) 	|

This still has an issue where when translating the alt text, the images are temporarily replaced with images from the posts above. I'm not sure if this is a translation issue or an issue with reloading the media view and how to fix it. Additionally, as the translation button is part of the TextStatusDisplayItem, it is only shown for posts containing translatable text.

Closes https://github.com/sk22/megalodon/issues/763