### PR TITLE
feat: re-add 12 hour option to polls

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposePollViewController.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewcontrollers/ComposePollViewController.java
@@ -42,6 +42,7 @@ public class ComposePollViewController{
 			30*60,
 			3600,
 			6*3600,
+			12*3600,
 			24*3600,
 			3*24*3600,
 			7*24*3600,


### PR DESCRIPTION
Restores the 12-hour poll option that was previously added to https://github.com/sk22/megalodon/pull/346, but no longer available in the latest release.