### PR TITLE
feat: add option to view poll results

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -550,6 +550,14 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		submitPollVote(holder.getItemID(), poll.id, poll.selectedOptions.stream().map(opt->poll.options.indexOf(opt)).collect(Collectors.toList()));
 	}
 
+	public void onPollViewResultsButtonClick(PollFooterStatusDisplayItem.Holder holder, boolean shown){
+			for(int i=0;i<list.getChildCount();i++){
+				if(list.getChildViewHolder(list.getChildAt(i)) instanceof PollOptionStatusDisplayItem.Holder item && item.getItemID().equals(holder.getItemID())){
+					item.showResults(shown);
+				}
+			}
+	}
+
 	protected void submitPollVote(String parentID, String pollID, List<Integer> choices){
 		if(refreshing)
 			return;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollFooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollFooterStatusDisplayItem.java
@@ -14,6 +14,7 @@ import org.joinmastodon.android.ui.utils.UiUtils;
 
 public class PollFooterStatusDisplayItem extends StatusDisplayItem{
 	public final Poll poll;
+	public boolean resultsVisible = false;
 
 	public PollFooterStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, Poll poll){
 		super(parentID, parentFragment);
@@ -27,13 +28,20 @@ public class PollFooterStatusDisplayItem extends StatusDisplayItem{
 
 	public static class Holder extends StatusDisplayItem.Holder<PollFooterStatusDisplayItem>{
 		private TextView text;
-		private Button button;
+		private Button voteButton, resultsButton;
 
 		public Holder(Activity activity, ViewGroup parent){
 			super(activity, R.layout.display_item_poll_footer, parent);
 			text=findViewById(R.id.text);
-			button=findViewById(R.id.vote_btn);
-			button.setOnClickListener(v->item.parentFragment.onPollVoteButtonClick(this));
+			voteButton=findViewById(R.id.vote_btn);
+			voteButton.setOnClickListener(v->item.parentFragment.onPollVoteButtonClick(this));
+			resultsButton=findViewById(R.id.results_btn);
+			resultsButton.setOnClickListener(v-> {
+				item.resultsVisible = !item.resultsVisible;
+				item.parentFragment.onPollViewResultsButtonClick(this, item.resultsVisible);
+				resultsButton.setText(item.resultsVisible ? R.string.sk_poll_view : R.string.sk_poll_results);
+				setVoteButtonEnabled();
+			});
 		}
 
 		@Override
@@ -48,8 +56,12 @@ public class PollFooterStatusDisplayItem extends StatusDisplayItem{
 				text+=" "+sep+" "+item.parentFragment.getString(R.string.poll_closed);
 			}
 			this.text.setText(text);
-			button.setVisibility(item.poll.isExpired() || item.poll.voted || (!item.poll.multiple && !GlobalUserPreferences.voteButtonForSingleChoice) ? View.GONE : View.VISIBLE);
-			button.setEnabled(item.poll.selectedOptions!=null && !item.poll.selectedOptions.isEmpty());
+			setVoteButtonEnabled();
+		}
+
+		private void setVoteButtonEnabled() {
+			voteButton.setVisibility(item.poll.isExpired() || item.poll.voted || (!item.poll.multiple && !GlobalUserPreferences.voteButtonForSingleChoice) ? View.GONE : View.VISIBLE);
+			voteButton.setEnabled(item.poll.selectedOptions!=null && !item.poll.selectedOptions.isEmpty() && !item.resultsVisible);
 		}
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollFooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollFooterStatusDisplayItem.java
@@ -14,7 +14,7 @@ import org.joinmastodon.android.ui.utils.UiUtils;
 
 public class PollFooterStatusDisplayItem extends StatusDisplayItem{
 	public final Poll poll;
-	public boolean resultsVisible = false;
+	public boolean resultsVisible=false;
 
 	public PollFooterStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, Poll poll){
 		super(parentID, parentFragment);
@@ -39,8 +39,7 @@ public class PollFooterStatusDisplayItem extends StatusDisplayItem{
 			resultsButton.setOnClickListener(v-> {
 				item.resultsVisible = !item.resultsVisible;
 				item.parentFragment.onPollViewResultsButtonClick(this, item.resultsVisible);
-				resultsButton.setText(item.resultsVisible ? R.string.sk_poll_view : R.string.sk_poll_results);
-				setVoteButtonEnabled();
+				rebind();
 			});
 		}
 
@@ -56,10 +55,7 @@ public class PollFooterStatusDisplayItem extends StatusDisplayItem{
 				text+=" "+sep+" "+item.parentFragment.getString(R.string.poll_closed);
 			}
 			this.text.setText(text);
-			setVoteButtonEnabled();
-		}
-
-		private void setVoteButtonEnabled() {
+			resultsButton.setText(item.resultsVisible ? R.string.sk_poll_view : R.string.sk_poll_results);
 			voteButton.setVisibility(item.poll.isExpired() || item.poll.voted || (!item.poll.multiple && !GlobalUserPreferences.voteButtonForSingleChoice) ? View.GONE : View.VISIBLE);
 			voteButton.setEnabled(item.poll.selectedOptions!=null && !item.poll.selectedOptions.isEmpty() && !item.resultsVisible);
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
@@ -17,6 +17,7 @@ import org.joinmastodon.android.ui.text.HtmlParser;
 import org.joinmastodon.android.ui.utils.CustomEmojiHelper;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
+import java.util.Collections;
 import java.util.Locale;
 
 import me.grishka.appkit.imageloader.ImageLoaderViewHolder;
@@ -44,6 +45,10 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 		text=HtmlParser.parseCustomEmoji(option.title, poll.emojis);
 		emojiHelper.setText(text);
 		showResults=poll.isExpired() || poll.voted;
+		calculateResults();
+	}
+
+	private void calculateResults() {
 		int total=poll.votersCount>0 ? poll.votersCount : poll.votesCount;
 		if(showResults && option.votesCount!=null && total>0){
 			votesFraction=(float)option.votesCount/(float)total;
@@ -134,6 +139,12 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 
 		private void onButtonClick(View v){
 			item.parentFragment.onPollOptionClick(this);
+		}
+
+		public void showResults(boolean shown) {
+			item.showResults = shown;
+			item.calculateResults();
+			rebind();
 		}
 	}
 }

--- a/mastodon/src/main/res/layout/display_item_poll_footer.xml
+++ b/mastodon/src/main/res/layout/display_item_poll_footer.xml
@@ -20,6 +20,16 @@
 		tools:text="fdsafdsafsdafds"/>
 
 	<Button
+		android:id="@+id/results_btn"
+		style="@style/Widget.Mastodon.M3.Button.Text"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginHorizontal="16dp"
+		android:minHeight="48dp"
+		android:textAppearance="@style/m3_label_small"
+		android:textAllCaps="true"
+		android:text="@string/sk_poll_results"/>
+	<Button
 		android:id="@+id/vote_btn"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -656,4 +656,6 @@
 	<string name="manage_list_members">Manage list members</string>
 	<string name="list_no_members">No members yet</string>
 	<string name="list_find_users">Find users to add</string>
+	<string name="sk_poll_results">View results</string>
+	<string name="sk_poll_view">Hide results</string>
 </resources>


### PR DESCRIPTION
Adds a button to view the results of a poll without voting. This is also available in the web interface.

![Web Interface with View Results Button](https://github.com/sk22/megalodon/assets/63370021/3d3e3b36-7621-49b4-b7a0-6c00187b090d)

https://github.com/sk22/megalodon/assets/63370021/4cb45f00-232f-4974-a9d8-e07c5f272828

I'm not quite sure about the button design, I'd prefer something more like the web interface, near the info text, but that has some problems on the mobile form factor. Feel free to improve it :)