### PR TITLE
fix: hide link card to akkoma hastags

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/model/Card.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Card.java
@@ -48,12 +48,10 @@ public class Card extends BaseModel{
 		}
 	}
 
-	public boolean isAkkomaHashtag(String statusUrl) {
+	public boolean isHashtagUrl(String statusUrl){
 		Uri parsedUrl=Uri.parse(url);
 		Uri parsedStatusUrl=Uri.parse(statusUrl);
-		if(parsedUrl.getHost()==null || parsedUrl.getPath()==null || parsedStatusUrl.getHost()==null)
-			return false;
-
+		if(parsedUrl.getHost()==null || parsedUrl.getPath()==null || parsedStatusUrl.getHost()==null) return false;
 		return title.equals("Akkoma") && parsedUrl.getHost().equals(parsedStatusUrl.getHost()) && parsedUrl.getPath().startsWith("/tag/");
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Card.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Card.java
@@ -2,6 +2,7 @@ package org.joinmastodon.android.model;
 
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -45,6 +46,15 @@ public class Card extends BaseModel{
 			if(placeholder!=null)
 				blurhashPlaceholder=new BlurHashDrawable(placeholder, width, height);
 		}
+	}
+
+	public boolean isAkkomaHashtag(String statusUrl) {
+		Uri parsedUrl=Uri.parse(url);
+		Uri parsedStatusUrl=Uri.parse(statusUrl);
+		if(parsedUrl.getHost()==null || parsedUrl.getPath()==null || parsedStatusUrl.getHost()==null)
+			return false;
+
+		return title.equals("Akkoma") && parsedUrl.getHost().equals(parsedStatusUrl.getHost()) && parsedUrl.getPath().startsWith("/tag/");
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -7,6 +7,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -29,6 +30,7 @@ import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.Attachment;
 import org.joinmastodon.android.model.DisplayItemsParent;
 import org.joinmastodon.android.model.FilterAction;
+import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.LegacyFilter;
 import org.joinmastodon.android.model.FilterContext;
 import org.joinmastodon.android.model.FilterResult;
@@ -46,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -293,7 +296,7 @@ public abstract class StatusDisplayItem{
 		if(statusForContent.poll!=null){
 			buildPollItems(parentID, fragment, statusForContent.poll, status, contentItems);
 		}
-		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty() && statusForContent.quote==null){
+		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty() && statusForContent.quote==null && !statusForContent.card.isAkkomaHashtag(statusForContent.url)){
 			contentItems.add(new LinkCardStatusDisplayItem(parentID, fragment, statusForContent));
 		}
 		if(statusForContent.quote!=null && !(parentObject instanceof Notification)){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -7,7 +7,6 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -29,8 +28,6 @@ import org.joinmastodon.android.fragments.ThreadFragment;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.Attachment;
 import org.joinmastodon.android.model.DisplayItemsParent;
-import org.joinmastodon.android.model.FilterAction;
-import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.LegacyFilter;
 import org.joinmastodon.android.model.FilterContext;
 import org.joinmastodon.android.model.FilterResult;
@@ -48,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -296,7 +292,7 @@ public abstract class StatusDisplayItem{
 		if(statusForContent.poll!=null){
 			buildPollItems(parentID, fragment, statusForContent.poll, status, contentItems);
 		}
-		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty() && statusForContent.quote==null && !statusForContent.card.isAkkomaHashtag(statusForContent.url)){
+		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty() && statusForContent.quote==null && !statusForContent.card.isHashtagUrl(statusForContent.url)){
 			contentItems.add(new LinkCardStatusDisplayItem(parentID, fragment, statusForContent));
 		}
 		if(statusForContent.quote!=null && !(parentObject instanceof Notification)){


### PR DESCRIPTION
Hides the link card generated by Akkoma instances for hashtags in posts. This will only happen if the card URL points to the same server, starts with `/tag/`, and has `Akkoma` as the title.
This is an improvement for both newer users, who may be confused by a link card appearing without a link, and experienced users, who may be annoyed by an unnecessary link card.

| Before                                                                                                         	| After                                                                                                              	|
|----------------------------------------------------------------------------------------------------------------	|--------------------------------------------------------------------------------------------------------------------	|
| ![Post with link card](https://github.com/sk22/megalodon/assets/63370021/d3e39c59-1e0e-4a6d-805e-d97c23c8538b) 	| ![Posts without link card](https://github.com/sk22/megalodon/assets/63370021/69171832-d649-4644-9f13-694fba2f447c) 	|