### PR TITLE
Quote display fixes

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -619,6 +619,8 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 			displayItems.addAll(index+1, spoilerItem.contentItems);
 			adapter.notifyItemRangeInserted(index+1, spoilerItem.contentItems.size());
 		}else{
+			if(spoilers.size()>1 && !isForQuote && status.quote.spoilerRevealed)
+				toggleSpoiler(status.quote, true, itemID);
 			displayItems.subList(index+1, index+1+spoilerItem.contentItems.size()).clear();
 			adapter.notifyItemRangeRemoved(index+1, spoilerItem.contentItems.size());
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -631,19 +631,23 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		list.invalidateItemDecorations();
 	}
 
-	public void onEnableExpandable(TextStatusDisplayItem.Holder holder, boolean expandable) {
+	public void onEnableExpandable(TextStatusDisplayItem.Holder holder, boolean expandable, boolean isForQuote) {
 		Status s=holder.getItem().status;
 		if(s.textExpandable!=expandable && list!=null) {
 			s.textExpandable=expandable;
-			HeaderStatusDisplayItem.Holder header=findHolderOfType(holder.getItemID(), HeaderStatusDisplayItem.Holder.class);
+			List<HeaderStatusDisplayItem.Holder> headers=findAllHoldersOfType(holder.getItemID(), HeaderStatusDisplayItem.Holder.class);
+			HeaderStatusDisplayItem.Holder header=headers.size() > 1 && isForQuote ? headers.get(1) : headers.get(0);
 			if(header!=null) header.bindCollapseButton();
 		}
 	}
 
-	public void onToggleExpanded(Status status, String itemID) {
+	public void onToggleExpanded(Status status, boolean isForQuote, String itemID) {
 		status.textExpanded = !status.textExpanded;
-		notifyItemChanged(itemID, TextStatusDisplayItem.class);
-		HeaderStatusDisplayItem.Holder header=findHolderOfType(itemID, HeaderStatusDisplayItem.Holder.class);
+		List<TextStatusDisplayItem.Holder> textItems = findAllHoldersOfType(itemID, TextStatusDisplayItem.Holder.class);
+		TextStatusDisplayItem.Holder text = textItems.size() > 1 && isForQuote ? textItems.get(1) : textItems.get(0);
+		adapter.notifyItemChanged(text.getAbsoluteAdapterPosition());
+		List<HeaderStatusDisplayItem.Holder> headers=findAllHoldersOfType(itemID, HeaderStatusDisplayItem.Holder.class);
+		HeaderStatusDisplayItem.Holder header=headers.size() > 1 && isForQuote ? headers.get(1) : headers.get(0);
 		if(header!=null) header.animateExpandToggle();
 		else notifyItemChanged(itemID, HeaderStatusDisplayItem.class);
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
@@ -181,6 +181,7 @@ public class ThreadFragment extends StatusListFragment implements ProvidesAssist
 				s.spoilerRevealed = oldStatus.spoilerRevealed;
 				s.sensitiveRevealed = oldStatus.sensitiveRevealed;
 				s.filterRevealed = oldStatus.filterRevealed;
+				s.textExpanded = oldStatus.textExpanded;
 			}
 			if (GlobalUserPreferences.autoRevealEqualSpoilers != AutoRevealMode.NEVER &&
 					s.spoilerText != null &&
@@ -257,6 +258,13 @@ public class ThreadFragment extends StatusListFragment implements ProvidesAssist
 		updatedStatus.filterRevealed = mainStatus.filterRevealed;
 		updatedStatus.spoilerRevealed = mainStatus.spoilerRevealed;
 		updatedStatus.sensitiveRevealed = mainStatus.sensitiveRevealed;
+		updatedStatus.textExpanded = mainStatus.textExpanded;
+		if(updatedStatus.quote!=null && mainStatus.quote!=null){
+			updatedStatus.quote.filterRevealed = mainStatus.quote.filterRevealed;
+			updatedStatus.quote.spoilerRevealed = mainStatus.quote.spoilerRevealed;
+			updatedStatus.quote.sensitiveRevealed = mainStatus.quote.sensitiveRevealed;
+			updatedStatus.quote.textExpanded = mainStatus.quote.textExpanded;
+		}
 
 		// returning fired event object to facilitate testing
 		Object event;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
@@ -173,7 +173,7 @@ public class HeaderStatusDisplayItem extends StatusDisplayItem{
 					fragment.removeNotification(item.notification);
 				}
 			}));
-			collapseBtn.setOnClickListener(l -> item.parentFragment.onToggleExpanded(item.status, getItemID()));
+			collapseBtn.setOnClickListener(l -> item.parentFragment.onToggleExpanded(item.status, item.isForQuote, getItemID()));
 
 			optionsMenu=new PopupMenu(activity, more);
 			optionsMenu.inflate(R.menu.post);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -295,7 +295,7 @@ public abstract class StatusDisplayItem{
 		if(statusForContent.card!=null && statusForContent.mediaAttachments.isEmpty() && statusForContent.quote==null && !statusForContent.card.isHashtagUrl(statusForContent.url)){
 			contentItems.add(new LinkCardStatusDisplayItem(parentID, fragment, statusForContent));
 		}
-		if(statusForContent.quote!=null && !(parentObject instanceof Notification)){
+		if(statusForContent.quote!=null && (flags & FLAG_INSET)==0){
 			if(!statusForContent.mediaAttachments.isEmpty() && statusForContent.poll==null) // add spacing if immediately preceded by attachment
 				contentItems.add(new DummyStatusDisplayItem(parentID, fragment));
 			contentItems.addAll(buildItems(fragment, statusForContent.quote, accountID, parentObject, knownAccounts, filterContext, FLAG_NO_FOOTER | FLAG_INSET | FLAG_NO_EMOJI_REACTIONS | FLAG_IS_FOR_QUOTE));

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/TextStatusDisplayItem.java
@@ -98,7 +98,7 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 			float textCollapsedHeight=activity.getResources().getDimension(R.dimen.text_collapsed_height);
 			collapseParams=new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (int) textCollapsedHeight);
 			wrapParams=new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-			readMore.setOnClickListener(v -> item.parentFragment.onToggleExpanded(item.status, getItemID()));
+			readMore.setOnClickListener(v -> item.parentFragment.onToggleExpanded(item.status, item.isForQuote, getItemID()));
 		}
 
 		@Override
@@ -152,7 +152,7 @@ public class TextStatusDisplayItem extends StatusDisplayItem{
 			if (GlobalUserPreferences.collapseLongPosts && !item.status.textExpandable) {
 				boolean tooBig = text.getMeasuredHeight() > textMaxHeight;
 				boolean expandable = tooBig && !item.status.hasSpoiler();
-				item.parentFragment.onEnableExpandable(Holder.this, expandable);
+				item.parentFragment.onEnableExpandable(Holder.this, expandable, item.isForQuote);
 			}
 
 			boolean expandButtonShown=item.status.textExpandable && !item.status.textExpanded;


### PR DESCRIPTION
This fixes a few issues with displaying quoted posts:
- Expanding long posts didn't work well and opening the thread would collapse it again (I just made it so refreshing a thread doesn't collapse the expanded posts as that seems to be the expected behavior anyways)
- Quote posts wouldn't show up in notifications i.e. when tagged in a quote post
- Part of the quoted post could still be shown after collapsing a content warning in some cases