### PR TITLE
feat: add option to mute notifications to muting dialog

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
@@ -6,7 +6,8 @@ import org.joinmastodon.android.model.Relationship;
 public class SetAccountMuted extends MastodonAPIRequest<Relationship>{
 	public SetAccountMuted(String id, boolean muted, long duration, boolean muteNotifications){
 		super(HttpMethod.POST, "/accounts/"+id+"/"+(muted ? "mute" : "unmute"), Relationship.class);
-		setRequestBody(new Request(duration, muteNotifications));
+		if(muted)
+			setRequestBody(new Request(duration, muteNotifications));
 	}
 
 	private static class Request{

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
@@ -4,15 +4,17 @@ import org.joinmastodon.android.api.MastodonAPIRequest;
 import org.joinmastodon.android.model.Relationship;
 
 public class SetAccountMuted extends MastodonAPIRequest<Relationship>{
-	public SetAccountMuted(String id, boolean muted, long duration){
+	public SetAccountMuted(String id, boolean muted, long duration, boolean muteNotifications){
 		super(HttpMethod.POST, "/accounts/"+id+"/"+(muted ? "mute" : "unmute"), Relationship.class);
-		setRequestBody(new Request(duration));
+		setRequestBody(new Request(duration, muteNotifications));
 	}
 
 	private static class Request{
 		public long duration;
-		public Request(long duration){
+		public boolean muteNotifications;
+		public Request(long duration, boolean muteNotifications){
 			this.duration=duration;
+			this.muteNotifications=muteNotifications;
 		}
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -61,6 +61,7 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
+import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -567,6 +568,8 @@ public class UiUtils {
 		durationView.setLayoutParams(params);
 		Button button=durationView.findViewById(R.id.button);
 		((TextView) durationView.findViewById(R.id.message)).setText(context.getString(R.string.confirm_mute, account.getDisplayName()));
+		Switch muteNotificationsSwitch=durationView.findViewById(R.id.mute_notifications_switch);
+		durationView.findViewById(R.id.mute_notifications).setOnClickListener(l->muteNotificationsSwitch.setChecked(!muteNotificationsSwitch.isChecked()));
 
 		AtomicReference<Duration> muteDuration=new AtomicReference<>(Duration.ZERO);
 
@@ -603,7 +606,7 @@ public class UiUtils {
 				.setMessage(currentlyMuted ? context.getString(R.string.confirm_unmute, account.getDisplayName()) : null)
 				.setView(currentlyMuted ? null : durationView)
 				.setPositiveButton(context.getString(currentlyMuted ? R.string.do_unmute : R.string.do_mute), (dlg, i)->{
-					new SetAccountMuted(account.id, !currentlyMuted, muteDuration.get().getSeconds())
+					new SetAccountMuted(account.id, !currentlyMuted, muteDuration.get().getSeconds(), muteNotificationsSwitch.isChecked())
 							.setCallback(new Callback<>(){
 								@Override
 								public void onSuccess(Relationship result){

--- a/mastodon/src/main/res/layout/mute_user_dialog.xml
+++ b/mastodon/src/main/res/layout/mute_user_dialog.xml
@@ -15,6 +15,35 @@
 		android:text="@string/confirm_mute"
 		android:textSize="16sp"/>
 
+	<LinearLayout
+		android:id="@+id/mute_notifications"
+		android:orientation="horizontal"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:minHeight="48dp"
+		android:gravity="center_vertical"
+		android:layoutDirection="locale">
+
+		<TextView
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:paddingVertical="8dp"
+			android:textSize="16sp"
+			android:textColor="?android:textColorPrimary"
+			android:text="@string/sk_mute_notifications_label" />
+
+		<org.joinmastodon.android.ui.views.M3Switch
+			android:id="@+id/mute_notifications_switch"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="16dp"
+			android:checked="true"
+			android:focusable="false"
+			android:clickable="false"/>
+
+	</LinearLayout>
+
 	<org.joinmastodon.android.ui.views.AutoOrientationLinearLayout
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
@@ -28,7 +57,7 @@
 			android:paddingVertical="8dp"
 			android:gravity="center_vertical"
 			android:textColor="?android:textColorPrimary"
-			android:text="@string/sk_mute_label"
+			android:text="@string/sk_mute_duration_label"
 			android:textSize="16sp"/>
 
 		<Button

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -372,7 +372,8 @@
     <string name="sk_button_react">React with emoji</string>
     <string name="sk_enter_emoji_toast">Please type an emoji</string>
     <string name="sk_enter_emoji_hint">Type an emoji or search</string>
-    <string name="sk_mute_label">Duration</string>
+    <string name="sk_mute_duration_label">Duration</string>
+	<string name="sk_mute_notifications_label">Mute Notifications?</string>
     <string name="sk_duration_indefinite">Indefinite</string>
     <string name="sk_duration_minutes_5">5 minutes</string>
     <string name="sk_duration_minutes_30">30 minutes</string>


### PR DESCRIPTION
Adds a new toggle to the Mute dialog that allows users to specify if they want to mute the user's notifications. The toggle is enabled by default. This brings parity with the web interface.

![Mute dialog with toggle to mute notifications](https://github.com/sk22/megalodon/assets/63370021/54bab966-c083-477b-aaa5-5baa1fcb295c)

Closes https://github.com/sk22/megalodon/issues/966
https://github.com/LucasGGamerM/moshidon/issues/331