### PR TITLE
Bumps me.grishka.appkit:appkit to 1.2.15, fixes IllegalStateException on emoji/user picker

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 	implementation 'me.grishka.litex:viewpager:1.0.0'
 	implementation 'me.grishka.litex:viewpager2:1.0.0'
 	implementation 'me.grishka.litex:palette:1.0.0'
-	implementation 'me.grishka.appkit:appkit:1.2.14'
+	implementation 'me.grishka.appkit:appkit:1.2.15'
 	implementation 'com.google.code.gson:gson:2.9.0'
 	implementation 'org.jsoup:jsoup:1.14.3'
 	implementation 'com.squareup:otto:1.3.8'


### PR DESCRIPTION
The IllegalStateException was removed on 1.2.15: https://github.com/grishka/appkit/commit/9cacd1b11bd0ce4bc1419071a6aaf32965e86124, according to them, "No, it wasn't a good idea to throw that exception".

This fixes #920, which was, on personal experience, an awfully annoying bug to deal with it.

I have literally never done a PR on a project on my life, please let me know if I need to do something else.