### PR TITLE
Fix NullPointerException with double push

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -148,9 +148,9 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		}
 	}
 
-	public void notifyUnifiedPush(Context context, String accountID, org.joinmastodon.android.model.Notification notification) {
+	public void notifyUnifiedPush(Context context, AccountSession account, org.joinmastodon.android.model.Notification notification) {
 		// push notifications are only created from the official push notification, so we create a fake from by transforming the notification
-		PushNotificationReceiver.this.notify(context, PushNotification.fromNotification(context, notification), accountID, notification);
+		PushNotificationReceiver.this.notify(context, PushNotification.fromNotification(context, account, notification), account.getID(), notification);
 	}
 
 	private void notify(Context context, PushNotification pn, String accountID, org.joinmastodon.android.model.Notification notification){

--- a/mastodon/src/main/java/org/joinmastodon/android/UnifiedPushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/UnifiedPushNotificationReceiver.java
@@ -72,7 +72,7 @@ public class UnifiedPushNotificationReceiver extends MessagingReceiver{
 				result.items
 						.stream()
 						.findFirst()
-						.ifPresent(value->MastodonAPIController.runInBackground(()->new PushNotificationReceiver().notifyUnifiedPush(context, instance, value)));
+						.ifPresent(value->MastodonAPIController.runInBackground(()->new PushNotificationReceiver().notifyUnifiedPush(context, account, value)));
 			}
 
 			@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/model/PushNotification.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/PushNotification.java
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.RequiredField;
+import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
 import androidx.annotation.StringRes;
@@ -23,7 +24,7 @@ public class PushNotification extends BaseModel{
 	@RequiredField
 	public String body;
 
-	public static PushNotification fromNotification(Context context, Notification notification){
+	public static PushNotification fromNotification(Context context, AccountSession account, Notification notification){
 		PushNotification pushNotification = new PushNotification();
 		pushNotification.notificationType = switch(notification.type) {
 			case FOLLOW -> PushNotification.Type.FOLLOW;
@@ -52,8 +53,12 @@ public class PushNotification extends BaseModel{
 		});
 
 		pushNotification.title = UiUtils.generateFormattedString(notificationTitle, notification.account.displayName).toString();
-		pushNotification.icon = notification.status.account.avatarStatic;
-		pushNotification.body = notification.status.getStrippedText();
+		if (notification.status != null) {
+			pushNotification.icon = notification.status.account.avatarStatic;
+			pushNotification.body = notification.status.getStrippedText();
+		} else {
+			pushNotification.icon = account.getDefaultAvatarUrl();
+		}
 		return pushNotification;
 	}
 


### PR DESCRIPTION
I often experience a NullPointer Exception on double push:

```
java.lang.NullPointerException: Attempt to read from field 'org.joinmastodon.android.model.Account org.joinmastodon.android.model.Status.account' on a null object reference in method 'org.joinmastodon.android.model.PushNotification org.joinmastodon.android.model.PushNotification.fromNotification(android.content.Context, org.joinmastodon.android.model.Notification)'
	at org.joinmastodon.android.model.PushNotification.fromNotification(SourceFile:55)
	at org.joinmastodon.android.PushNotificationReceiver.notifyUnifiedPush(SourceFile:153)
	at org.joinmastodon.android.UnifiedPushNotificationReceiver$1.lambda$onSuccess$0(SourceFile:75)
	at org.joinmastodon.android.UnifiedPushNotificationReceiver$1.$r8$lambda$4J7AuBytjmt8335OwYDlx1gnhvU(SourceFile:0)
	at org.joinmastodon.android.UnifiedPushNotificationReceiver$1$$ExternalSyntheticLambda0.run(SourceFile:0)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at me.grishka.appkit.utils.WorkerThread.run(SourceFile:54)
```

This fixes this issue.

![Screenshot](https://github.com/sk22/megalodon/assets/31284753/0180ad54-935b-4c25-ae44-6c0d3cde7a4a)

