### PR TITLE
feat: dispay inline avatar in thread replies

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ReblogOrReplyLineStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ReblogOrReplyLineStatusDisplayItem.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
+import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.Emoji;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.model.StatusPrivacy;
@@ -47,12 +48,13 @@ public class ReblogOrReplyLineStatusDisplayItem extends StatusDisplayItem{
 	public boolean needBottomPadding;
 	ReblogOrReplyLineStatusDisplayItem extra;
 	CharSequence fullText;
+	CharSequence boostingTimestamp;
 
 	public ReblogOrReplyLineStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, CharSequence text, List<Emoji> emojis, @DrawableRes int icon, StatusPrivacy visibility, @Nullable View.OnClickListener handleClick, Status status) {
-		this(parentID, parentFragment, text, emojis, icon, visibility, handleClick, text, status);
+		this(parentID, parentFragment, text, emojis, icon, visibility, handleClick, text, status, null);
 	}
 
-	public ReblogOrReplyLineStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, CharSequence text, List<Emoji> emojis, @DrawableRes int icon, StatusPrivacy visibility, @Nullable View.OnClickListener handleClick, CharSequence fullText, Status status) {
+	public ReblogOrReplyLineStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, CharSequence text, List<Emoji> emojis, @DrawableRes int icon, StatusPrivacy visibility, @Nullable View.OnClickListener handleClick, CharSequence fullText, Status status, Account account) {
 		super(parentID, parentFragment);
 		SpannableStringBuilder ssb=new SpannableStringBuilder(text);
 		if(AccountSessionManager.get(parentFragment.getAccountID()).getLocalPreferences().customEmojiInNames)
@@ -63,6 +65,14 @@ public class ReblogOrReplyLineStatusDisplayItem extends StatusDisplayItem{
 			ssb.insert(0, "  ");
 			ssb.setSpan(new AvatarSpan(status.account), 0, 1, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 			ssb.setSpan(new SpacerSpan(15, 20), 1, 2, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+		}
+		int replyPrefixLength=context.getString(R.string.in_reply_to).length()-2; //subtract 2 for placeholder
+		if(status.inReplyToAccountId!=null&&ssb.length()>replyPrefixLength&&account!=null){
+			//add temp chars for span replacement, should be same as spans added below
+			ssb.insert(replyPrefixLength, "   ");
+			ssb.setSpan(new SpacerSpan(15, 20), replyPrefixLength+1, replyPrefixLength+2, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+			ssb.setSpan(new AvatarSpan(account), replyPrefixLength+1, replyPrefixLength+2, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+			ssb.setSpan(new SpacerSpan(15, 20), replyPrefixLength+2, replyPrefixLength+3, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 		}
 		this.text=ssb;
 		emojiHelper.setText(ssb);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ReblogOrReplyLineStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ReblogOrReplyLineStatusDisplayItem.java
@@ -58,7 +58,7 @@ public class ReblogOrReplyLineStatusDisplayItem extends StatusDisplayItem{
 		if(AccountSessionManager.get(parentFragment.getAccountID()).getLocalPreferences().customEmojiInNames)
 			HtmlParser.parseCustomEmoji(ssb, emojis);
 
-		if(status.reblog!=null){
+		if(status.reblog!=null&&handleClick!=null){
 			//add temp chars for span replacement, should be same as spans added below
 			ssb.insert(0, "  ");
 			ssb.setSpan(new AvatarSpan(status.account), 0, 1, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ReblogOrReplyLineStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ReblogOrReplyLineStatusDisplayItem.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,7 +19,10 @@ import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.Emoji;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.model.StatusPrivacy;
+import org.joinmastodon.android.ui.text.AvatarSpan;
+import org.joinmastodon.android.ui.text.CustomEmojiSpan;
 import org.joinmastodon.android.ui.text.HtmlParser;
+import org.joinmastodon.android.ui.text.SpacerSpan;
 import org.joinmastodon.android.ui.utils.CustomEmojiHelper;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
@@ -53,6 +57,13 @@ public class ReblogOrReplyLineStatusDisplayItem extends StatusDisplayItem{
 		SpannableStringBuilder ssb=new SpannableStringBuilder(text);
 		if(AccountSessionManager.get(parentFragment.getAccountID()).getLocalPreferences().customEmojiInNames)
 			HtmlParser.parseCustomEmoji(ssb, emojis);
+
+		if(status.reblog!=null){
+			//add temp chars for span replacement, should be same as spans added below
+			ssb.insert(0, "  ");
+			ssb.setSpan(new AvatarSpan(status.account), 0, 1, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+			ssb.setSpan(new SpacerSpan(15, 20), 1, 2, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+		}
 		this.text=ssb;
 		emojiHelper.setText(ssb);
 		this.fullText=fullText;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -151,7 +151,7 @@ public abstract class StatusDisplayItem{
 				: fragment.getString(R.string.in_reply_to, account.getDisplayName());
 		return new ReblogOrReplyLineStatusDisplayItem(
 				parentID, fragment, text, account == null ? List.of() : account.emojis,
-				R.drawable.ic_fluent_arrow_reply_20sp_filled, null, null, fullText, status
+				R.drawable.ic_fluent_arrow_reply_20sp_filled, null, null, fullText, status, account
 		);
 	}
 
@@ -182,7 +182,7 @@ public abstract class StatusDisplayItem{
 				items.add(new ReblogOrReplyLineStatusDisplayItem(parentID, fragment, text, status.account.emojis, R.drawable.ic_fluent_arrow_repeat_all_20sp_filled, isOwnPost ? status.visibility : null, i->{
 					args.putParcelable("profileAccount", Parcels.wrap(status.account));
 					Nav.go(fragment.getActivity(), ProfileFragment.class, args);
-				}, null, status));
+				}, null, status, status.account));
 			} else if (!(status.tags.isEmpty() ||
 					fragment instanceof HashtagTimelineFragment ||
 					fragment instanceof ListTimelineFragment

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/AvatarSpan.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/AvatarSpan.java
@@ -1,0 +1,50 @@
+package org.joinmastodon.android.ui.text;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.text.style.ReplacementSpan;
+
+import org.joinmastodon.android.GlobalUserPreferences;
+import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.model.Emoji;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import me.grishka.appkit.imageloader.requests.UrlImageLoaderRequest;
+import me.grishka.appkit.utils.V;
+
+public class AvatarSpan extends CustomEmojiSpan{
+
+	public AvatarSpan(Account account){
+		//this is a hacky solution to allow loading of avatars in the middle of strings,
+		//using already existing code for loading emojis
+		super(new Emoji(account.avatarStatic, account.avatar, account.avatarStatic));
+	}
+
+	@Override
+	public void draw(@NonNull Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, @NonNull Paint paint){
+		//modified draw of a CustomEmojiSpan, drawing a circular image instead.
+		if(drawable==null)
+			return;
+		int size=Math.round(paint.descent()-paint.ascent());
+		Rect bounds=drawable.getBounds();
+		int dw=drawable.getIntrinsicWidth();
+		int dh=drawable.getIntrinsicHeight();
+		if(bounds.left!=0 || bounds.top!=0 || bounds.right!=dw || bounds.left!=dh){
+			drawable.setBounds(0, 0, dw, dh);
+		}
+		canvas.save();
+		float radius = size / 2f;
+		Path clipPath = new Path();
+		clipPath.addCircle(x + radius, top + radius, radius, Path.Direction.CW);
+		canvas.clipPath(clipPath);
+		canvas.translate(x, top);
+		canvas.scale(size/(float)dw, size/(float)dh, 0f, 0f);
+		drawable.draw(canvas);
+		canvas.restore();
+	}
+
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/CustomEmojiSpan.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/CustomEmojiSpan.java
@@ -16,7 +16,7 @@ import me.grishka.appkit.utils.V;
 
 public class CustomEmojiSpan extends ReplacementSpan{
 	public final Emoji emoji;
-	private Drawable drawable;
+	protected Drawable drawable;
 
 	public CustomEmojiSpan(Emoji emoji){
 		this.emoji=emoji;


### PR DESCRIPTION
Builds on https://github.com/sk22/megalodon/pull/977 to also show the avatar in the thread reply to line. This makes it easier to see who the reply is addressed to.

![Reply with inline avatar icon](https://github.com/sk22/megalodon/assets/63370021/4b358b4c-fda6-4d37-9aa4-b2079487797b)

Makes it more visible in a longer thread
![Thread with inline avatars](https://github.com/sk22/megalodon/assets/63370021/40cfb8e8-4474-4c6d-938e-079e4d1f6d7a)
