### PR TITLE
fix: Properly submit posts after previewing

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -1124,6 +1124,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 			public void onSuccess(Status result){
 				if(preview){
 					openPreview(result);
+					uuid=null;
 					return;
 				}
 
@@ -1562,7 +1563,6 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 		}
 
 		contentTypePopup.setOnMenuItemClickListener(i->{
-			uuid=null;
 			int index=i.getItemId();
 			contentType=ContentType.values()[index];
 			btn.setSelected(index!=ContentType.UNSPECIFIED.ordinal() && index!=ContentType.PLAIN.ordinal());


### PR DESCRIPTION
The UUID wasn't getting reset after previewing a post on Akkoma which meant that the server would still treat the post as being previewed when trying to submit it