### PR TITLE
Fix for #965 - don't backup accounts.json

### DIFF
--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
 	<application
 		android:name=".MastodonApp"
 		android:allowBackup="true"
+		android:dataExtractionRules="@xml/backup_rules"
 		android:label="@string/sk_app_name"
 		android:supportsRtl="true"
 		android:localeConfig="@xml/locales_config"

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -85,6 +85,7 @@ public class AccountSessionManager{
 
 	private AccountSessionManager(){
 		prefs=MastodonApp.context.getSharedPreferences("account_manager", Context.MODE_PRIVATE);
+		// This file should not be backed up, otherwise the app may start with accounts already logged in. See res/xml/backup_rules.xml
 		File file=new File(MastodonApp.context.getFilesDir(), "accounts.json");
 		if(!file.exists())
 			return;

--- a/mastodon/src/main/res/xml/backup_rules.xml
+++ b/mastodon/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+	<cloud-backup>
+		<exclude domain="file" path="accounts.json"/>
+	</cloud-backup>
+</data-extraction-rules>


### PR DESCRIPTION
Tested the suggested theory of disabling backup of accounts.json. I think this is fixing https://github.com/sk22/megalodon/issues/965 - I was reproducing it consistently, and have not been able to reproduce with this change.